### PR TITLE
[SUITE EVAL-85]: feat(pdf): #EVAL-191 add generation pdf including pagination

### DIFF
--- a/src/main/java/fr/openent/competences/service/ExportService.java
+++ b/src/main/java/fr/openent/competences/service/ExportService.java
@@ -18,6 +18,7 @@
 package fr.openent.competences.service;
 
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
@@ -50,6 +51,19 @@ public interface ExportService {
 
     void genererPdf(final HttpServerRequest request, final JsonObject templateProps, final String templateName,
                     final String prefixPdfName, Vertx vertx, JsonObject config);
+
+    /**
+     * Generate PDF by proceeding template html first before generating its buffer with PDF sequentially
+     *
+     * @param request       HttpServerRequest to send response  {@link HttpServerRequest}
+     * @param templateProps Props object to send for proceeding template {@link JsonObject}
+     * @param templateName  Name of the template used for proceeding template {@link String} (e.g bulletin.pdf.xhtml...)
+     * @param title         Title of the pdf {@link String}
+     * @param vertx         Vertx instance {@link Vertx}
+     * @param config        config module entcore instance {@link JsonObject}
+     */
+    void generateSchoolReportPdf(HttpServerRequest request, JsonObject templateProps, String templateName, String title,
+                                 Vertx vertx, JsonObject config);
 
     void getMatiereExportReleveComp(final JsonArray idMatieres, Handler<Either<String, String>> handler);
 

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
@@ -13,6 +13,9 @@ import fr.wseduc.webutils.Either;
 import fr.wseduc.webutils.I18n;
 import fr.wseduc.webutils.data.FileResolver;
 import fr.wseduc.webutils.http.Renders;
+import fr.wseduc.webutils.template.TemplateProcessor;
+import fr.wseduc.webutils.template.lambdas.I18nLambda;
+import fr.wseduc.webutils.template.lambdas.LocaleDateLambda;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
@@ -25,8 +28,10 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.apache.pdfbox.exceptions.COSVisitorException;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.util.PDFMergerUtility;
 import org.entcore.common.bus.WorkspaceHelper;
 import org.entcore.common.http.request.JsonHttpServerRequest;
 import org.entcore.common.neo4j.Neo4j;
@@ -49,6 +54,7 @@ import static fr.openent.competences.helpers.NodePdfGeneratorClientHelper.*;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLTimeoutException;
@@ -746,7 +752,8 @@ public class DefaultExportBulletinService implements ExportBulletinService{
                         if(isNotNull(params.getValue("simple")) && params.getBoolean("simple")) {
                             template = "bulletin_lycee.pdf.xhtml";
                         }
-                        exportService.genererPdf(request, resultFinal, template, title, vertx, config);
+
+                        exportService.generateSchoolReportPdf(request, resultFinal, template, title, vertx, config);
 
                         JsonObject jsonRequest = new JsonObject()
                                 .put("headers", new JsonObject()

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
@@ -519,7 +519,7 @@ public class DefaultExportBulletinService implements ExportBulletinService{
                 }
             }
 
-            String footer = "";
+            String caption = "";
             if(!footerArray.isEmpty()){
                 for (int i = 0; i < footerArray.size(); i++) {
                     JsonObject niv = footerArray.getJsonObject(i);
@@ -536,12 +536,12 @@ public class DefaultExportBulletinService implements ExportBulletinService{
                         id_niv = id_cycle;
                     }
 
-                    footer += id_niv + " : " + lib + " - ";
+                    caption += id_niv + " : " + lib + " - ";
                 }
-                footer = footer.substring(0, footer.length() - 2);
+                caption = caption.substring(0, caption.length() - 2);
             }
 
-            eleve.put(NIVEAU_COMPETENCE, niveauCompetences).put("footer", "* " + footer);
+            eleve.put(NIVEAU_COMPETENCE, niveauCompetences).put("caption", "* " + caption);
 
             if(isNotNull(params.getValue(AGRICULTURE_LOGO)) && params.getBoolean(AGRICULTURE_LOGO)){
                 eleve.put(LOGO_PATH, "img/ministere_agriculture.png");
@@ -1812,8 +1812,11 @@ public class DefaultExportBulletinService implements ExportBulletinService{
     }
 
     private void setHeightByRow(JsonArray subjects) {
-        int sizeOfTable = 600; // Taille en pixel du tableau de suivi des acquis
         int nbSubject = subjects.size();
+        int sizeOfTable = 580; // Taille en pixel du tableau de suivi des acquis
+        if(nbSubject > 0 && subjects.getJsonObject(0).getBoolean(GET_POSITIONNEMENT)) {
+            sizeOfTable -= 20;
+        }
         for (int i = 0; i < nbSubject; i++) {
             JsonObject subject = subjects.getJsonObject(i);
             subject.put("heightByRow", (sizeOfTable / nbSubject) + "px");

--- a/src/main/resources/public/template/pdf/bulletin.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/bulletin.pdf.xhtml
@@ -368,10 +368,6 @@
             padding-top: 2px;
             padding-bottom: 2px;
         }
-
-        .suiviDesAcquis {
-            height: 700px;
-        }
     </style>
 </head>
 <body>
@@ -483,7 +479,7 @@
 
     {{#hasSuiviAcquis}}
     <h1 color="blue">{{suiviAcquisLibelle}}</h1>
-    <table class="suiviDesAcquis paddingFifty">
+    <table class="paddingFifty">
         <tr class="header">
             <td>&nbsp;</td>
             {{#getProgramElements}}
@@ -788,7 +784,7 @@
         {{/printMoyenneGenerale}}
     </table>
     {{#getPositionnement}}
-    <span class="paddingFifty" style="font-size: xx-small;"> {{footer}}</span>
+    <span class="paddingFifty" style="font-size: xx-small;">{{caption}}</span>
     {{/getPositionnement}}
     {{/hasSuiviAcquis}}
 

--- a/src/main/resources/public/template/pdf/bulletin.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/bulletin.pdf.xhtml
@@ -280,7 +280,7 @@
             margin-bottom: 40px;
 
             @bottom-right {
-                /*content: counter(page) "/" counter(pages);*/
+                content: counter(page) "/" counter(pages);
                 font-size: x-small;
                 padding-right: 10px;
             }
@@ -291,8 +291,6 @@
         }
 
         @page:first {
-            margin-bottom: 0 !important;
-
             @bottom-center {
                 content: normal;
             }

--- a/src/main/resources/public/template/pdf/bulletin_lycee.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/bulletin_lycee.pdf.xhtml
@@ -210,7 +210,7 @@
             margin-bottom: 40px;
 
             @bottom-right {
-                /*content: counter(page) "/" counter(pages);*/
+                content: counter(page) "/" counter(pages);
                 font-size: x-small;
                 padding-right: 10px;
             }

--- a/src/main/resources/public/template/pdf/bulletin_lycee.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/bulletin_lycee.pdf.xhtml
@@ -221,8 +221,6 @@
         }
 
         @page:first {
-            margin-bottom: 0 !important;
-
             @bottom-center {
                 content: normal;
             }
@@ -292,10 +290,6 @@
             height: 10px;
             padding-top: 2px;
             padding-bottom: 2px;
-        }
-
-        .suiviDesAcquis {
-            height: 700px;
         }
     </style>
 </head>
@@ -404,7 +398,7 @@
     <br/>
     {{#hasSuiviAcquis}}
     <div class="paddingFifty">
-        <table class="suiviDesAcquis">
+        <table>
             <tr class="header">
                 <td>&nbsp;</td>
                 {{#getProgramElements}}


### PR DESCRIPTION
https://entsupport.gdapublic.fr/browse/EVAL-191

Avant on faisait un `processTemplate` pour tous les élèves  et on faisait une génération PDF globale
Le problème étant que la pagination était accumulée pour tous les élèves

On fait un traitement pour faire le `processTemplate` et la génération PDF pour chaque élève.
A la fin de tout ce traitement, on merge tous les PDFs en un.

Résultat : 

![pdf1](https://user-images.githubusercontent.com/10532050/135620697-769c670f-8a4b-444e-b41d-05bee94d59ec.PNG)

![pdf2](https://user-images.githubusercontent.com/10532050/135620716-f06e04b5-fc76-485c-89d8-b241617cec78.PNG)

![pdf3](https://user-images.githubusercontent.com/10532050/135620729-0f9df963-8e6f-4bed-838a-ad56226654e2.PNG)


