### PR TITLE
fix(memento): #EVAL-270 fix ko period value when successively opening …

### DIFF
--- a/src/main/resources/public/ts/sniplets/memento/notes.ts
+++ b/src/main/resources/public/ts/sniplets/memento/notes.ts
@@ -266,6 +266,7 @@ const vm: IViewModel = {
         vm.structure = new Structure({id: window.structure.id});
         vm.structure.niveauCompetences.sync();
         vm.notes = await DevoirsService.getLatestNotes(window.structure.id, vm.student);
+        vm.arrayPeriodSubjects = [];
 
         await vm.loadPeriods();
         if (vm.arrayPeriodSubjects.length === 0) {


### PR DESCRIPTION
…memento

Bug due to an unemptied array when reopening a memento.