### PR TITLE
fix:(Bulletins) : Eval 325/eleve suppr

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Describe your changes
+
+## Checklist tests
+
+## Issue ticket number and link
+
+## Checklist before requesting a review (magic string, indentation, comment/documentation...)
+
+- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
+- [ ] If it is a consequent feature, I have added thorough tests.
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] Any dependent changes have been added to this project (must specify in **Description**)
+

--- a/deployment/competences/conf.json.template
+++ b/deployment/competences/conf.json.template
@@ -1,5 +1,5 @@
     {
-      "name": "fr.openent~competences~1.36.0",
+      "name": "fr.openent~competences~1.36-SNAPSHOT",
       "config": {
         "main" : "fr.openent.competences.Competences",
         "port" : 8129,

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ modowner=fr.openent
 modname=competences
 
 # Your module version
-version=1.36.0
+version=1.36-SNAPSHOT
 
 # The test timeout in seconds
 testtimeout=300

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
@@ -34,19 +34,8 @@ import org.entcore.common.neo4j.Neo4jResult;
 import org.entcore.common.sql.Sql;
 import org.entcore.common.sql.SqlResult;
 import org.entcore.common.storage.Storage;
+
 import javax.imageio.ImageIO;
-
-import static fr.openent.competences.Competences.*;
-import static fr.openent.competences.Utils.getLibelle;
-import static fr.openent.competences.Utils.isNotNull;
-import static fr.openent.competences.Utils.isNull;
-import static fr.openent.competences.service.impl.BulletinWorker.SAVE_BULLETIN;
-import static fr.openent.competences.service.impl.DefaultExportService.COEFFICIENT;
-import static fr.openent.competences.service.impl.DefaultNoteService.*;
-import static fr.openent.competences.utils.ArchiveUtils.getFileNameForStudent;
-import static fr.openent.competences.helpers.FormateFutureEvent.formate;
-import static fr.openent.competences.helpers.NodePdfGeneratorClientHelper.*;
-
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.math.RoundingMode;
@@ -55,11 +44,18 @@ import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static fr.openent.competences.Competences.*;
+import static fr.openent.competences.Utils.*;
+import static fr.openent.competences.helpers.FormateFutureEvent.formate;
+import static fr.openent.competences.helpers.NodePdfGeneratorClientHelper.*;
+import static fr.openent.competences.service.impl.BulletinWorker.SAVE_BULLETIN;
+import static fr.openent.competences.service.impl.DefaultExportService.COEFFICIENT;
+import static fr.openent.competences.service.impl.DefaultNoteService.*;
+import static fr.openent.competences.utils.ArchiveUtils.getFileNameForStudent;
 import static fr.openent.competences.utils.BulletinUtils.getIdParentForStudent;
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 
@@ -2796,9 +2792,18 @@ public class DefaultExportBulletinService implements ExportBulletinService{
 
                     //Faire le libelle
                     classeStudent.setPeriode(periode);
-
-                    JsonArray groupes = eleve.getJsonArray("idGroupes");
-                    JsonArray manualGroupes = eleve.getJsonArray("idManualGroupes");
+                    JsonArray groupes,manualGroupes = new JsonArray();
+                    try {
+                         groupes = eleve.getJsonArray("idGroupes");
+                    }catch (ClassCastException e){
+                        String groupesStr = eleve.getString("idGroupes");
+                        String[] array = groupesStr.split(",");
+                        groupes = new JsonArray();
+                        for(String s : array){
+                            groupes.add(s);
+                        }
+                    }
+                    manualGroupes.addAll(eleve.getJsonArray("idManualGroupes",new JsonArray()));
 
                     for (int j = 0; j < groupes.size(); j++) {
                         Group group = new Group();

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
@@ -2795,7 +2795,7 @@ public class DefaultExportBulletinService implements ExportBulletinService{
                     JsonArray groupes,manualGroupes = new JsonArray();
                     try {
                          groupes = eleve.getJsonArray("idGroupes");
-                    }catch (ClassCastException e){
+                    } catch (ClassCastException e){
                         String groupesStr = eleve.getString("idGroupes");
                         String[] array = groupesStr.split(",");
                         groupes = new JsonArray();

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportBulletinService.java
@@ -2792,7 +2792,7 @@ public class DefaultExportBulletinService implements ExportBulletinService{
 
                     //Faire le libelle
                     classeStudent.setPeriode(periode);
-                    JsonArray groupes,manualGroupes = new JsonArray();
+                    JsonArray groupes, manualGroupes = new JsonArray();
                     try {
                          groupes = eleve.getJsonArray("idGroupes");
                     } catch (ClassCastException e){
@@ -2803,7 +2803,7 @@ public class DefaultExportBulletinService implements ExportBulletinService{
                             groupes.add(s);
                         }
                     }
-                    manualGroupes.addAll(eleve.getJsonArray("idManualGroupes",new JsonArray()));
+                    manualGroupes.addAll(eleve.getJsonArray("idManualGroupes", new JsonArray()));
 
                     for (int j = 0; j < groupes.size(); j++) {
                         Group group = new Group();

--- a/src/main/java/fr/openent/competences/service/impl/DefaultMongoExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultMongoExportService.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class DefaultMongoExportService implements MongoExportService {
     private Logger log = LoggerFactory.getLogger(DefaultMongoExportService.class);
@@ -70,7 +71,17 @@ public class DefaultMongoExportService implements MongoExportService {
         List<Future<String>> futureArray= new ArrayList<>();
         for(Object studentJO : students){
             JsonObject student = (JsonObject) studentJO;
-            student.remove("u.deleteDate");
+
+            //besoin 2 loops sinon erreur de json
+            List<String> keysToDelete = new ArrayList<>();
+            for (Map.Entry<String, Object> map : student) {
+                String key = map.getKey();
+                if(key.startsWith("$") || key.contains("."))
+                    keysToDelete.add(key);
+            }
+            for(String key : keysToDelete){
+                student.remove(key);
+            }
             common.put("eleve",student);
             Promise<String> promise = Promise.promise();
             this.createWhenStart("pdf", common,

--- a/src/main/java/fr/openent/competences/service/impl/DefaultMongoExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultMongoExportService.java
@@ -68,7 +68,7 @@ public class DefaultMongoExportService implements MongoExportService {
         }catch (Exception e){
             log.info(String.format("[Competences@%s::setFuturesToInsertMongo] an error has occurred during insert data in mongo: %s.", this.getClass().getSimpleName(), e.getMessage()));
         }
-        List<Future<String>> futureArray= new ArrayList<>();
+        List<Future<String>> futureArray = new ArrayList<>();
         for(Object studentJO : students){
             JsonObject student = (JsonObject) studentJO;
 


### PR DESCRIPTION
## Describe your changes
Fix :
-  Bug lors de l'export Bulletin : "id_groupes" était parfois un string au lieu d un JsonArray
- Bug lors de l'export Bulletin : Présence d'un "$" au début d une clé JsonObject au moment de l insertion en mongo

## Checklist tests

- [x] Exporter un élève supprimé 
- [x] Avec Postman passer des paramètres avec "$" au début de la clé

## Issue ticket number and link

 https://entsupport.gdapublic.fr/browse/EVAL-325

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

