### PR TITLE
feat: EVAL-334 add snipplet to choose the caculation of skill items And apply choice to competence

### DIFF
--- a/src/main/java/fr/openent/competences/Competences.java
+++ b/src/main/java/fr/openent/competences/Competences.java
@@ -320,6 +320,7 @@ public class Competences extends BaseServer {
         addController(new AppreciationSubjectPeriodController(eb));
         addController(new DigitalSkillsController());
         addController(new SuperAdminController());
+        addController(new StructureOptionsController());
         // Devoir Controller
         DevoirController devoirController = new DevoirController(eb, eventStore);
         SqlCrudService devoirSqlCrudService = new SqlCrudService(COMPETENCES_SCHEMA, DEVOIR_TABLE, DEVOIR_SHARE_TABLE,

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -27,6 +27,9 @@ public class Field {
     // tables
     public static final String STRUTUCTURE_OPTIONS = "structure_options";
 
+    //colonne
+    public static final String IS_AVERAGE_SKILLS = "is_average_skills";
+
     //schema json
     public static final String SCHEMA_EVAL_CREATEORUPDATESTRUCTUREOPTIONISAVERAGESKILLS =
             "eval_createOrUpdateStructureOptionIsAverageSkills";

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -23,12 +23,18 @@ public class Field {
     public static final String SAVE_BFC = "saveBFC";
     public static final String STRUCTUREID = "structureId";
     public static final String ISSKILLAVERAGE = "isSkillAverage";
+    public static final String IDCLASSE = "idClasse";
+    public static final String TYPECLASSE = "typeClasse";
+    public static final String IDDOMAINE = "idDomaine";
+    public static final String IDPERIODE = "idPeriode";
+    public static final String ERROR = "error";
 
     // tables
     public static final String STRUTUCTURE_OPTIONS = "structure_options";
 
     //colonne
     public static final String IS_AVERAGE_SKILLS = "is_average_skills";
+    public static final String EVALUATION = "evaluation";
 
     //schema json
     public static final String SCHEMA_EVAL_CREATEORUPDATESTRUCTUREOPTIONISAVERAGESKILLS =

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -21,6 +21,18 @@ public class Field {
 
     //variables
     public static final String SAVE_BFC = "saveBFC";
+    public static final String STRUCTUREID = "structureId";
+    public static final String ISSKILLAVERAGE = "isSkillAverage";
+
+    // tables
+    public static final String STRUTUCTURE_OPTIONS = "structure_options";
+
+    //schema json
+    public static final String SCHEMA_EVAL_CREATEORUPDATESTRUCTUREOPTIONISAVERAGESKILLS =
+            "eval_createOrUpdateStructureOptionIsAverageSkills";
+
+
+
     public static final String ID_DEVOIR = "idDevoir";
     public static final String ID_STRUCTURE = "idStructure";
 

--- a/src/main/java/fr/openent/competences/controllers/StructureOptionsController.java
+++ b/src/main/java/fr/openent/competences/controllers/StructureOptionsController.java
@@ -1,0 +1,71 @@
+package fr.openent.competences.controllers;
+
+import fr.openent.competences.constants.Field;
+import fr.openent.competences.security.AdministratorRight;
+import fr.openent.competences.service.StructureOptionsService;
+import fr.openent.competences.service.impl.DefaultStructureOptions;
+import fr.wseduc.rs.ApiDoc;
+import fr.wseduc.rs.Get;
+import fr.wseduc.rs.Post;
+import fr.wseduc.security.ActionType;
+import fr.wseduc.security.SecuredAction;
+import fr.wseduc.webutils.request.RequestUtils;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.controller.ControllerHelper;
+import org.entcore.common.http.filter.ResourceFilter;
+import org.entcore.common.user.UserUtils;
+
+import static org.entcore.common.http.response.DefaultResponseHandler.defaultResponseHandler;
+
+public class StructureOptionsController extends ControllerHelper {
+
+    protected static final Logger log = LoggerFactory.getLogger(StructureOptionsController.class);
+
+    private final StructureOptionsService structureOptionService;
+
+    public StructureOptionsController () {
+        this.structureOptionService = new DefaultStructureOptions();
+    }
+
+    @Get("/structure/:structureId/options/isSkillAverage")
+    @ApiDoc(" create and update structure_ options isAverableSkills")
+    @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
+    public void getStructureOptionIsAverage (HttpServerRequest request) {
+        String structureId = request.getParam(Field.STRUCTUREID);
+        structureOptionService.getIsAverageSkills(structureId, defaultResponseHandler(request));
+    }
+
+    @Post("/structure/options/isSkillAverage")
+    @ApiDoc(" create and update structure_options isSkillAverage")
+    @ResourceFilter(AdministratorRight.class)
+    @SecuredAction(value = "", type= ActionType.RESOURCE)
+    public void createOrUpdateIsAverageSkills (final HttpServerRequest request){
+        UserUtils.getUserInfos(eb, request, user -> {
+            if( user != null) {
+                RequestUtils.bodyToJson(request,pathPrefix + Field.SCHEMA_EVAL_CREATEORUPDATESTRUCTUREOPTIONISAVERAGESKILLS,
+                        body -> {
+
+                    if (isStructureOptionBodyInvalid(body)) {
+                        badRequest(request, "params request does not valid");
+                        return;
+                    }
+                    structureOptionService.createOrUpdateIsAverageSkills(body,
+                            defaultResponseHandler(request));
+                });
+            } else {
+                unauthorized(request, "user is not valid");
+            }
+        });
+
+    }
+
+    private boolean isStructureOptionBodyInvalid (JsonObject body) {
+        return !body.containsKey(Field.STRUCTUREID) && !body.containsKey(Field.ISSKILLAVERAGE);
+    }
+
+
+
+}

--- a/src/main/java/fr/openent/competences/service/CompetenceNoteService.java
+++ b/src/main/java/fr/openent/competences/service/CompetenceNoteService.java
@@ -104,7 +104,16 @@ public interface CompetenceNoteService extends CrudService {
      */
     void dropCompetencesNotesDevoir(JsonArray oIdsJsonArray, Handler<Either<String, JsonArray>> handler);
 
-    void getMaxCompetenceNoteEleveByPeriod (String[] idEleves, Long idPeriode, Boolean isYear, Handler<Either<String, JsonArray>> handler);
+    /**
+     * Get max or average competenceNote
+     * @param idEleves id Eleves
+     * @param idPeriode id Periode
+     * @param isYear isYear
+     * @param isSkillAverage isSkillAverage
+     * @param  handler handler
+     */
+    void getMaxOrAverageCompetenceNoteEleveByPeriod (String[] idEleves, Long idPeriode, Boolean isYear, Boolean isSkillAverage,
+                                            Handler<Either<String, JsonArray>> handler);
 
     /**
      * Récupère toutes les compétences notes d'un élève
@@ -117,27 +126,21 @@ public interface CompetenceNoteService extends CrudService {
     void getCompetencesNotesEleve(String idEleve, Long idPeriode, Long idCycle, boolean isCycle, Handler<Either<String, JsonArray>> handler);
 
     /**
-     * Récupère toutes les compétences notes d'une classe
+     * Récupère toutes les compétences notes d'une classe soit le max de la note chaque item soit la moyenne des notes de chaque item
+     * pour un periode donnée ou l'année
      * @param idEleves identifiant des élèves de la classe
      * @param idPeriode identifiant de la période
+     * @param isSkillAverage chois du calcul
      * @param handler handler portant le résultat de la requête
      */
-    void getCompetencesNotesClasse(List<String> idEleves, Long idPeriode, Handler<Either<String, JsonArray>> handler);
-
-    /**
-     * Récupère toutes les compétences notes d'une classe
-     * @param idEleves identifiant des élèves de la classe
-     * @param idPeriode identifiant de la période
-     * @param handler handler portant le résultat de la requête
-     * @param idDomaines filtre sur les domaines
-     */
-    void getCompetencesNotesDomaineClasse(List<String> idEleves, Long idPeriode, List<String> idDomaines, Handler<Either<String, JsonArray>> handler);
+    void getMaxOrAverageCompetencesNotesClasse(List<String> idEleves, Long idPeriode, Boolean isSkillAverage,
+                                               Handler<Either<String, JsonArray>> handler);
 
     /**
      * Récupère la table de correspendance entre (Moyenne Note - Evaluation competence) d'un cycle et etablissment donné
      * @param idEtablissement identifiant de l'établissement
      * @param idclasse identifiant de la classe
-     * @param handler
+     * @param handler handler
      **/
     void getConversionNoteCompetence(String idEtablissement, String idclasse, Handler<Either<String, JsonArray>> handler);
 
@@ -148,7 +151,8 @@ public interface CompetenceNoteService extends CrudService {
      * @param isClassList boolean for the params of request
      * @param handler response
      */
-    void getConversionTableByClass(String idEtablissement, List<String> idsClasses, Boolean isClassList, Handler<Either<String, JsonArray>> handler);
+    void getConversionTableByClass(String idEtablissement, List<String> idsClasses, Boolean isClassList,
+                                   Handler<Either<String, JsonArray>> handler);
     /**
      * Récupère les cycles des groupes sur lequels un élève a des devoirs avec compétences notées
      * @param idEleve id de l'élève
@@ -156,7 +160,16 @@ public interface CompetenceNoteService extends CrudService {
      */
     void getCyclesEleve(String idEleve, Handler<Either<String, JsonArray>> handler);
 
-    void getMaxCompetenceNoteEleveByCycle (String[] id_eleve, Long idCycle, Handler<Either<String, JsonArray>> handler);
+    /**
+     * Récupère toutes les compétences notes d'une classe soit le max de la note chaque item soit la moyenne des notes de chaque item
+     * pour un cycle
+     * @param id_eleve identifiant des élèves de la classe
+     * @param idCycle id du cycle
+     * @param isSkillAverage choix du calcul
+     * @param handler handler portant le résultat de la requête
+     */
+    void getMaxOrAverageCompetenceNoteEleveByCycle (String[] id_eleve, Long idCycle, Boolean isSkillAverage,
+                                                    Handler<Either<String, JsonArray>> handler);
 
     /**
      * utilise la méthode getConversionNoteCompetence pour associer ordre du niveau de compétence au barème du brevet
@@ -164,5 +177,6 @@ public interface CompetenceNoteService extends CrudService {
      * @param idClasse id de la classe
      * @param handler retourne la réponse
      */
-    void getMaxBaremeMapOrderBaremeBrevet(String idEtablissement, String idClasse, Handler<Either<String,Map<Integer, Map<Integer,Integer>>>> handler);
+    void getMaxBaremeMapOrderBaremeBrevet(String idEtablissement, String idClasse,
+                                          Handler<Either<String,Map<Integer, Map<Integer,Integer>>>> handler);
 }

--- a/src/main/java/fr/openent/competences/service/NoteService.java
+++ b/src/main/java/fr/openent/competences/service/NoteService.java
@@ -229,7 +229,7 @@ public interface NoteService extends CrudService {
 
     void calculPositionnementAutoByEleveByMatiere(JsonArray listNotes, JsonObject result, Boolean annual,
                                                   JsonArray tableauConversion,
-                                                  List<String> idsClassWithNoteAppCompNoteStudent, Long idPeriodAsked);
+                                                  List<String> idsClassWithNoteAppCompNoteStudent, Long idPeriodAsked, boolean isAvgSkill);
 
     void getMoyennesFinal(String[] idEleves, Integer idPeriode, String[] idMatieres, String[] idClasses,
                           Handler<Either<String, JsonArray>> handler);

--- a/src/main/java/fr/openent/competences/service/StructureOptionsService.java
+++ b/src/main/java/fr/openent/competences/service/StructureOptionsService.java
@@ -1,6 +1,7 @@
 package fr.openent.competences.service;
 
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.service.CrudService;
@@ -20,5 +21,12 @@ public interface StructureOptionsService extends CrudService {
      * @param handler response contains is_average_skill boolean
      */
     void getIsAverageSkills (String structureId, Handler<Either<String, JsonObject>> handler);
+
+    /**
+     *
+     * @param structureId structure id
+     * @return response
+     */
+    Future<Boolean> isAverageSkills(String structureId);
 
 }

--- a/src/main/java/fr/openent/competences/service/StructureOptionsService.java
+++ b/src/main/java/fr/openent/competences/service/StructureOptionsService.java
@@ -1,0 +1,24 @@
+package fr.openent.competences.service;
+
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.service.CrudService;
+
+public interface StructureOptionsService extends CrudService {
+
+    /**
+     *
+     * @param body contain structureId String and isSkillAverage boolean
+     * @param handler response empty JsonObject
+     */
+    void createOrUpdateIsAverageSkills (JsonObject body, Handler<Either<String, JsonObject>> handler);
+
+    /**
+     *
+     * @param structureId structureId
+     * @param handler response contains is_average_skill boolean
+     */
+    void getIsAverageSkills (String structureId, Handler<Either<String, JsonObject>> handler);
+
+}

--- a/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
@@ -3,36 +3,34 @@ package fr.openent.competences.service.impl;
 import fr.openent.competences.Competences;
 import fr.openent.competences.Utils;
 import fr.openent.competences.bean.NoteDevoir;
+import fr.openent.competences.constants.Field;
+import fr.openent.competences.enums.EventType;
+import fr.openent.competences.message.MessageResponseHandler;
 import fr.openent.competences.service.*;
 import fr.wseduc.webutils.Either;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
+import io.vertx.core.*;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.sql.Sql;
-import fr.openent.competences.enums.*;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static fr.openent.competences.Competences.*;
 import static fr.openent.competences.Utils.isNotNull;
 import static fr.openent.competences.Utils.isNull;
+import static fr.openent.competences.helpers.FormateFutureEvent.formate;
 import static fr.openent.competences.service.impl.DefaultExportBulletinService.TIME;
 import static fr.openent.competences.service.impl.DefaultExportService.COEFFICIENT;
 import static fr.openent.competences.service.impl.DefaultNoteService.SOUS_MATIERES;
-import static fr.openent.competences.helpers.FormateFutureEvent.formate;
-
-import fr.openent.competences.message.MessageResponseHandler;
-
 import static org.entcore.common.sql.SqlResult.validResultHandler;
-import static org.entcore.common.sql.SqlResult.validUniqueResultHandler;
 
 public class DefaultBilanPerioqueService implements BilanPeriodiqueService{
     private static final Logger log = LoggerFactory.getLogger(DefaultBilanPerioqueService.class);
@@ -43,6 +41,8 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService{
     private final EventBus eb;
     private final Sql sql;
     private final MatiereService defautlMatiereService;
+    private final StructureOptionsService structureOptionsService;
+
 
     public DefaultBilanPerioqueService (EventBus eb){
         this.eb = eb;
@@ -51,6 +51,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService{
         devoirService = new DefaultDevoirService(eb);
         elementProgramme = new DefaultElementProgramme() ;
         defautlMatiereService = new DefaultMatiereService(eb);
+        structureOptionsService = new DefaultStructureOptions();
         sql = Sql.getInstance();
     }
 
@@ -472,24 +473,32 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService{
                     .getConversionNoteCompetence(idEtablissement, idClasse,  // note : Est ce que c'est pas l'idGroupeClasse qu'on doit passé ici ?
                             tableauEvent -> formate(tableauDeConversionFuture, tableauEvent));
 
+            Future<Boolean> isAvgSkillFuture = structureOptionsService.isAverageSkills(idEtablissement);
+
             Future<String> subjectFuture = Future.future();
             subjectsFuture.add(subjectFuture);
 
-            CompositeFuture.all(elementsProgFuture, appreciationMoyFinalePosFuture, notesFuture, compNotesFuture,
-                    moyenneFinaleFuture, tableauDeConversionFuture).setHandler(event -> {
-                if(event.succeeded()){
-                    List<String> idsClassWithNoteAppCompNoteStudent = new ArrayList<>();
-                    setAppreciationMoyFinalePositionnementEleve(result, appreciationMoyFinalePosFuture.result(),
-                            idsClassWithNoteAppCompNoteStudent);
-                    setMoyAndPosForSuivi(notesFuture.result(), compNotesFuture.result(), moyenneFinaleFuture.result(),
-                            result, idEleve, idPeriod, tableauDeConversionFuture.result(), idsClassWithNoteAppCompNoteStudent);
-                    setElementProgramme(result, elementsProgFuture.result(), idsClassWithNoteAppCompNoteStudent);
-                    results.add(result);
-                    subjectFuture.complete();
-                } else {
-                    subjectFuture.fail(event.cause().getMessage());
-                }
-            });
+            isAvgSkillFuture
+                    .onSuccess(isAvgSkillResult -> CompositeFuture.all(elementsProgFuture, appreciationMoyFinalePosFuture, notesFuture, compNotesFuture,
+                            moyenneFinaleFuture, tableauDeConversionFuture).setHandler(event -> {
+                        if(event.succeeded()){
+                            List<String> idsClassWithNoteAppCompNoteStudent = new ArrayList<>();
+                            setAppreciationMoyFinalePositionnementEleve(result, appreciationMoyFinalePosFuture.result(),
+                                    idsClassWithNoteAppCompNoteStudent);
+                            setMoyAndPosForSuivi(notesFuture.result(), compNotesFuture.result(), moyenneFinaleFuture.result(),
+                                    result, idEleve, idPeriod, tableauDeConversionFuture.result(), idsClassWithNoteAppCompNoteStudent, isAvgSkillResult );
+                            setElementProgramme(result, elementsProgFuture.result(), idsClassWithNoteAppCompNoteStudent);
+                            results.add(result);
+                            subjectFuture.complete();
+                        } else {
+                            subjectFuture.fail(event.cause().getMessage());
+                            log.error("[DefaultBilanPeriodique] : setSubjectLibelleAndTeachers subjectFuture " + event.cause().getMessage());
+                        }
+                    }))
+                    .onFailure(err ->{
+                        handler.handle(new Either.Left<>(err.getMessage()));
+                        log.error("[DefaultBilanPeriodique] : setSubjectLibelleAndTeachers isAvgSkillFuture " + err.getMessage());
+                    });
         }
 
         CompositeFuture.all(subjectsFuture).setHandler(event -> {
@@ -763,14 +772,14 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService{
 
     private void setMoyAndPosForSuivi(JsonArray notes, JsonArray compNotes, JsonArray moyFinalesEleves,
                                       JsonObject result, String idEleve, Long idPeriodAsked,
-                                      JsonArray tableauConversion, List<String> idsClassWithNoteAppCompNoteStudent) {
+                                      JsonArray tableauConversion, List<String> idsClassWithNoteAppCompNoteStudent, boolean isAvgSkill) {
         JsonArray idsEleves = new fr.wseduc.webutils.collections.JsonArray();
         HashMap<Long, HashMap<Long, ArrayList<NoteDevoir>>> notesByDevoirByPeriodeClasse =
                 noteService.calculMoyennesEleveByPeriode(notes, result, idEleve, idsEleves,
                         idsClassWithNoteAppCompNoteStudent, idPeriodAsked);
         noteService.getMoyennesMatieresByCoefficient(moyFinalesEleves, notes, result, idEleve, idsEleves);
         noteService.calculPositionnementAutoByEleveByMatiere(compNotes, result,false, tableauConversion,
-                idsClassWithNoteAppCompNoteStudent, idPeriodAsked);
+                idsClassWithNoteAppCompNoteStudent, idPeriodAsked, isAvgSkill);
         noteService.calculAndSetMoyenneClasseByPeriode(moyFinalesEleves, notesByDevoirByPeriodeClasse, result);
         noteService.setRankAndMinMaxInClasseByPeriode(idPeriodAsked, idEleve, notesByDevoirByPeriodeClasse,
                 moyFinalesEleves, result);

--- a/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
@@ -17,6 +17,31 @@
 
 package fr.openent.competences.service.impl;
 
+import fr.openent.competences.Competences;
+import fr.openent.competences.Utils;
+import fr.openent.competences.bean.*;
+import fr.openent.competences.constants.Field;
+import fr.openent.competences.service.*;
+import fr.wseduc.webutils.Either;
+import fr.wseduc.webutils.http.Renders;
+import io.vertx.core.*;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.service.impl.SqlCrudService;
+import org.entcore.common.sql.Sql;
+import org.entcore.common.sql.SqlResult;
+import org.entcore.common.user.UserInfos;
+
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
 import static fr.openent.competences.Competences.*;
 import static fr.openent.competences.Utils.*;
 import static fr.openent.competences.helpers.FormateFutureEvent.formate;
@@ -25,43 +50,6 @@ import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 import static fr.wseduc.webutils.http.Renders.badRequest;
 import static org.entcore.common.sql.SqlResult.validResultHandler;
 import static org.entcore.common.sql.SqlResult.validUniqueResultHandler;
-
-import java.math.RoundingMode;
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.stream.Collectors;
-
-import fr.openent.competences.service.*;
-import org.entcore.common.service.impl.SqlCrudService;
-import org.entcore.common.sql.Sql;
-import org.entcore.common.sql.SqlResult;
-import org.entcore.common.user.UserInfos;
-
-import fr.openent.competences.Competences;
-import fr.openent.competences.Utils;
-import fr.openent.competences.bean.*;
-import fr.wseduc.webutils.Either;
-import fr.wseduc.webutils.http.Renders;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.DeliveryOptions;
-import io.vertx.core.eventbus.EventBus;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 
 /**
  * Created by ledunoiss on 05/08/2016.
@@ -99,6 +87,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
     private UtilsService utilsService;
     private AnnotationService annotationService;
     private CompetenceNoteService competenceNoteService;
+    private StructureOptionsService structureOptionsService;
 
     protected static final Logger log = LoggerFactory.getLogger(DefaultNoteService.class);
 
@@ -112,6 +101,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         utilsService = new DefaultUtilsService(eb);
         annotationService = new DefaultAnnotationService(COMPETENCES_SCHEMA, REL_ANNOTATIONS_DEVOIRS_TABLE);
         competenceNoteService = new DefaultCompetenceNoteService(COMPETENCES_SCHEMA, COMPETENCES_NOTES_TABLE);
+        structureOptionsService = new DefaultStructureOptions();
     }
 
     @Override
@@ -500,7 +490,6 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         } else{
             idMatieres = null;
         }
-
         runGetCompetencesNotesReleve(etablissementId, matiereId, idMatieres, periodeId,
                 eleveId, idEleves, withDomaineInfo, isYear, handler);
     }
@@ -1266,8 +1255,8 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
 
         if(nbEleve!=0)
             return Double.valueOf(decimalFormat.format((sumMoyClasse / nbEleve)).replaceAll(",", "."));
-      else
-          return Double.valueOf(decimalFormat.format((sumMoyClasse / 1)).replaceAll(",", "."));
+        else
+            return Double.valueOf(decimalFormat.format((sumMoyClasse / 1)).replaceAll(",", "."));
     }
 
     public void calculAndSetMoyenneClasseByPeriode(final JsonArray moyFinalesEleves,
@@ -1397,7 +1386,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                 JsonObject moyFinaleJson = (JsonObject) moyFinale;
                 Long idP = moyFinaleJson.getLong("id_periode");
                 NoteDevoir noteEleve = (moyFinaleJson.getString("moyenne") != null) ?
-                new NoteDevoir(Double.valueOf(moyFinaleJson.getString("moyenne")),20.0, false, 1.0, moyFinaleJson.getString("id_eleve")) :
+                        new NoteDevoir(Double.valueOf(moyFinaleJson.getString("moyenne")),20.0, false, 1.0, moyFinaleJson.getString("id_eleve")) :
                         new NoteDevoir(null,20.0, false, 1.0, moyFinaleJson.getString("id_eleve"));
                 if(!notesByDevoirByPeriodeClasse.containsKey(idP))
                     notesByDevoirByPeriodeClasse.put(idP, new HashMap<>());
@@ -1526,11 +1515,11 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         }
         return notesByStudent;
     }
-    private void getMaxCompNoteByPeriode(JsonArray listCompNotes,
+    private void getMaxOrAvgCompNoteByPeriode(JsonArray listCompNotes,
                                          HashMap<Long, ArrayList<NoteDevoir>> notesByDevoirByPeriode,
                                          HashMap<Long, HashMap<Long, ArrayList<NoteDevoir>>> notesByPeriodeBySousMatiere,
                                          JsonArray tableauConversion,
-                                         List<String> idsClassWithNoteAppCompNoteStudent, Long idPeriodAsked){
+                                         List<String> idsClassWithNoteAppCompNoteStudent, Long idPeriodAsked, boolean isAvg){
         notesByDevoirByPeriode.put(null, new ArrayList<>());
 
         // 1- parcourir la listCompNotes pour en extraire les map map<idP, JAcompNote> et map<idP,map<idssM,JAcompNote>>
@@ -1541,6 +1530,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
             JsonObject compNote = listCompNotes.getJsonObject(i);
             Long id_periode = compNote.getLong(ID_PERIODE);
             Long idSousMatiere = compNote.getLong(ID_SOUS_MATIERE);
+
             String group_id = compNote.getString("id_groupe");
             Boolean isFormative = compNote.getBoolean("formative");
             if (isFormative) {
@@ -1566,19 +1556,18 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         }
         //2- loop map<idP, JAcompNote> -> JAcompNoteMaxByPeriode -> map<idP,list<NoteDevoirMax>> = notesByDevoirByPeriode
         compNotesByPeriode.forEach((id_period,compNotes) -> {
-            Map<String, JsonObject> MaxCompNotesByCompetence = calculMaxCompNoteItem(compNotes, tableauConversion,true);
 
-            MaxCompNotesByCompetence.forEach((id_comp,maxCompNote) -> {
+            Map<String, JsonObject> MaxOrAvgCompNotesByCompetence = calculMaxOrAvgCompNoteItem(compNotes, tableauConversion,true, isAvg);
+            MaxOrAvgCompNotesByCompetence.forEach((id_comp,maxCompNote) -> {
                 NoteDevoir noteDevoir;
-
-                Long niveauFinal = maxCompNote.getLong("niveau_final");
+                Double niveauFinal = maxCompNote.getDouble("niveau_final");
                 Long niveauFinalAnnuel = maxCompNote.getLong("niveau_final_annuel");
                 if (isNotNull(niveauFinalAnnuel) ) {
                     noteDevoir = new NoteDevoir(Double.valueOf(niveauFinalAnnuel)+1,1.0,false,1.0);
-                } else if (isNotNull(niveauFinal) ) {
+                }/* else if (isNotNull(niveauFinal) ) {
                     noteDevoir = new NoteDevoir(Double.valueOf(niveauFinal)+1,1.0,false,1.0);
-                } else {
-                    noteDevoir = new NoteDevoir(Double.valueOf(maxCompNote.getLong("evaluation"))+1, 1.0,
+                }*/ else {
+                    noteDevoir = new NoteDevoir(maxCompNote.getDouble("evaluation") +1, 1.0,
                             false, 1.0);
                 }
                 utilsService.addToMap(id_period, notesByDevoirByPeriode, noteDevoir);
@@ -1590,11 +1579,11 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         //3-loop map<idP,map<idssM,JAcompNote>> ->JAcompNoteMaxBySousMatByPerode -> map<idP,map<idssM,list<NoteDevoirMax>> = notesByPeriodeBySousMatiere
         compNotesBySousMatByPeriode.forEach((id_periode,mapSousMatCompNotes) ->{
             mapSousMatCompNotes.forEach((id_sousMat, compNotesSousMat) -> {
-                Map<String,JsonObject> MaxCompNoteSousMatByComp = calculMaxCompNoteItem(compNotesSousMat, tableauConversion,
-                        false);
+                Map<String,JsonObject> MaxOrAvgCompNoteSousMatByComp = calculMaxOrAvgCompNoteItem(compNotesSousMat, tableauConversion,
+                        false, isAvg);
 
-                MaxCompNoteSousMatByComp.forEach((id_comp,maxCompNoteSousMat) -> {
-                    NoteDevoir noteDevoir = new NoteDevoir(Double.valueOf(maxCompNoteSousMat.getLong("evaluation"))+1,
+                MaxOrAvgCompNoteSousMatByComp.forEach((id_comp,maxCompNoteSousMat) -> {
+                    NoteDevoir noteDevoir = new NoteDevoir(maxCompNoteSousMat.getDouble("evaluation") +1.d,
                             1.0, false, 1.0);
 
                     if(!notesByPeriodeBySousMatiere.containsKey(id_periode)) notesByPeriodeBySousMatiere.put(id_periode,
@@ -1608,7 +1597,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
     public void calculPositionnementAutoByEleveByMatiere(JsonArray listCompNotes, JsonObject result, Boolean annual,
                                                          JsonArray tableauConversion,
                                                          List<String> idsClassWithNoteAppCompNoteStudent,
-                                                         Long idPeriodAsked) {
+                                                         Long idPeriodAsked, boolean isAvgSkill) {
         HashMap<Long, JsonArray> listMoyDevoirs = new HashMap<>();
         HashMap<Long, ArrayList<NoteDevoir>> notesByDevoirByPeriode = new HashMap<>();
         HashMap<Long, HashMap<Long, ArrayList<NoteDevoir>>> notesByPeriodeBySousMatiere = new HashMap<>();
@@ -1616,8 +1605,8 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         result.put(POSITIONNEMENTS_AUTO, new JsonArray());
         result.put("_" + POSITIONNEMENTS_AUTO, new JsonObject());
 
-        getMaxCompNoteByPeriode(listCompNotes, notesByDevoirByPeriode,notesByPeriodeBySousMatiere, tableauConversion,
-                idsClassWithNoteAppCompNoteStudent, idPeriodAsked);
+        getMaxOrAvgCompNoteByPeriode(listCompNotes, notesByDevoirByPeriode,notesByPeriodeBySousMatiere, tableauConversion,
+                idsClassWithNoteAppCompNoteStudent, idPeriodAsked ,isAvgSkill);
 
         // Paramètre de calcul des moyennes de compétencesNotes
         Boolean withStat = false;
@@ -1630,6 +1619,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
             ArrayList<NoteDevoir> compNotesPeriode = entryPeriode.getValue();
             JsonObject moyenneMatiere = utilsService.calculMoyenne(compNotesPeriode, withStat, diviseur, annual);
             moyenneMatiere.put("id_periode", idPeriode);
+
             listMoyDevoirs.get(idPeriode).add(moyenneMatiere);
 
             // Calcul des moyennes des compétencesNotes par sousMatiere
@@ -1863,7 +1853,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                         //récupérer les moysFinales => set mapIdEleveIdMatMoy
                         if (moyenneFinale != null ) {
                             if(!mapAllidMatAndidTeachers.containsKey(idMatMoyF))
-                            setListTeachers(services, multiTeachers,mapAllidMatAndidTeachers,idMatMoyF);
+                                setListTeachers(services, multiTeachers,mapAllidMatAndidTeachers,idMatMoyF);
                             if(mapAllidMatAndidTeachers.containsKey(idMatMoyF)){//idMatMoyF is on service
                                 setMapIdEleveMatMoy(mapIdEleveIdMatMoy, moyenneFinale, idEleveMoyF, idMatMoyF);
                             } else {
@@ -2321,6 +2311,9 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                 List<Future> listFutures = new ArrayList<>(Arrays.asList(compNotesFuture, notesFuture,
                         moyennesFinalesFutures, appreciationsFutures, positionnementsFinauxFutures));
 
+                Future<Boolean> isAvgSkillFuture = structureOptionsService.isAverageSkills(idEtablissement);
+                listFutures.add(isAvgSkillFuture);
+
                 CompositeFuture.all(listFutures).setHandler( event -> {
                     if(event.succeeded()) {
                         // Rajout des moyennes finales
@@ -2336,7 +2329,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                         if (idPeriode != null) {
                             // Cacul du positionnement auto
                             calculMoyennesCompetencesNotesForReleve(compNotesFuture.result(), resultHandler,
-                                    idPeriode, tableauDeConversionFuture.result(), elevesMapObject);
+                                    idPeriode, tableauDeConversionFuture.result(), elevesMapObject, isAvgSkillFuture.result());
 
                             // Format sous matières moyennes
                             addSousMatieres(elevesMapObject, sousMatiereFuture.result(), resultHandler, idPeriode);
@@ -2434,7 +2427,10 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                                         null, true, annual,
                                         compNotesEvent -> formate(compNotesFuture, compNotesEvent));
 
+
+                                Future<Boolean> isAvgSkillFuture = structureOptionsService.isAverageSkills(idEtablissement);
                                 List<Future> listFutures = new ArrayList<>(Arrays.asList(bigRequestFuture, compNotesFuture, notesFuture));
+                                listFutures.add(isAvgSkillFuture);
                                 CompositeFuture.all(listFutures).setHandler(event -> {
                                     try{
                                         if(event.succeeded()) {
@@ -2510,7 +2506,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                                                         JsonObject resultNotes = new JsonObject();
                                                         calculPositionnementAutoByEleveByMatiere(compNotesEleve, resultNotes,
                                                                 annual, tableauDeConversionFuture.result(),
-                                                                null , null);
+                                                                null , null, isAvgSkillFuture.result());
                                                         if(eleveObject.containsKey(POSITIONNEMENT_AUTO)){
                                                             eleveObject.getJsonObject(POSITIONNEMENT_AUTO).put(idMatiere.toString(),
                                                                     resultNotes.getJsonArray(POSITIONNEMENTS_AUTO));
@@ -2994,7 +2990,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
 
     private <T> void calculMoyennesCompetencesNotesForReleve (JsonArray listCompNotes, JsonObject result, Long idPeriode,
                                                               JsonArray tableauDeconversion,
-                                                              Map<String, JsonObject> eleveMapObject) {
+                                                              Map<String, JsonObject> eleveMapObject, Boolean isAvgSkill) {
 
         Map<String, JsonArray> notesByEleve = groupeNotesByStudent(listCompNotes);
 
@@ -3013,7 +3009,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                             eleveObject.getJsonArray(COMPETENCES_NOTES_KEY).encode());
                 }
                 calculPositionnementAutoByEleveByMatiere(compNotesEleve, eleveObject,false, tableauDeconversion,
-                        null , null );
+                        null , null, isAvgSkill);
                 JsonObject positionnement = utilsService.getObjectForPeriode(
                         eleveObject.getJsonArray(POSITIONNEMENTS_AUTO), idPeriode, ID_PERIODE);
 
@@ -3509,110 +3505,117 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         // On récupère le tableau de conversion des compétences notes pour Lire le positionnement
         competenceNoteService.getConversionNoteCompetence(idEtablissement, idClasse, tableauEvent ->
                 formate(tableauDeConversionFuture, tableauEvent));
+        Future<Boolean> isAvgSkillFuture = structureOptionsService.isAverageSkills(idEtablissement);
 
-        CompositeFuture.all(compNoteF, noteF, subjectF, tableauDeConversionFuture).setHandler(event -> {
-            if(event.failed()){
-                String message = "[getReleveDataForGraph] " + event.cause().getMessage();
-                log.error(message);
-                handler.handle(new Either.Left<>(message));
-                return;
-            }
+        isAvgSkillFuture
+                .onSuccess(isAvgSkillpromiseResult -> CompositeFuture.all(compNoteF, noteF, subjectF, tableauDeConversionFuture).setHandler(event -> {
+                    if(event.failed()){
+                        String message = "[getReleveDataForGraph] " + event.cause().getMessage();
+                        log.error(message);
+                        handler.handle(new Either.Left<>(message));
+                        return;
+                    }
 
-            final JsonArray listCompNotes = compNoteF.result();
-            final JsonArray listNotes = noteF.result();
-            Map<String,JsonArray> matieresCompNotes = new HashMap<>();
-            Map<String,JsonArray> matieresCompNotesEleve = new HashMap<>();
+                    final JsonArray listCompNotes = compNoteF.result();
+                    final JsonArray listNotes = noteF.result();
+                    Map<String,JsonArray> matieresCompNotes = new HashMap<>();
+                    Map<String,JsonArray> matieresCompNotesEleve = new HashMap<>();
 
-            // 4. On regroupe  les compétences notes par idMatière
-            JsonArray idMatieres = groupDataByMatiere(listCompNotes, matieresCompNotes, matieresCompNotesEleve, idEleve,
-                    true);
+                    // 4. On regroupe  les compétences notes par idMatière
+                    JsonArray idMatieres = groupDataByMatiere(listCompNotes, matieresCompNotes, matieresCompNotesEleve, idEleve,
+                            true);
 
-            // 5. On regroupe les notes par idMatière
+                    // 5. On regroupe les notes par idMatière
 
-            Map<String,JsonArray> matieresNotes = new HashMap<>();
-            Map<String,JsonArray> matieresNotesEleve = new HashMap<>();
-            idMatieres = utilsService.saUnion(groupDataByMatiere(listNotes, matieresNotes, matieresNotesEleve, idEleve,
-                    false), idMatieres);
+                    Map<String,JsonArray> matieresNotes = new HashMap<>();
+                    Map<String,JsonArray> matieresNotesEleve = new HashMap<>();
+                    idMatieres = utilsService.saUnion(groupDataByMatiere(listNotes, matieresNotes, matieresNotesEleve, idEleve,
+                            false), idMatieres);
 
-            Map<String, StatClass> mapMatieresStatClasseAndEleve = new HashMap<>();
+                    Map<String, StatClass> mapMatieresStatClasseAndEleve = new HashMap<>();
 
-            StatMat statMat = new StatMat();
-            if(idPeriode != null) {
-                statMat.setMapIdMatStatclass(listNotes);
-                mapMatieresStatClasseAndEleve = statMat.getMapIdMatStatclass();
-            } else { // notes order by periode
-                Map<Integer, JsonArray> mapIdPeriodeNotes = getListNotesByPeriode(listNotes, false);
-                if(!mapIdPeriodeNotes.isEmpty()) {
-                    for (int i = 0; i < idMatieres.size(); i++) {
-                        String idMatiere = idMatieres.getString(i);
-                        List<NoteDevoir> listAverageClass = new ArrayList<>();
-                        List<NoteDevoir> listAverageStudent = new ArrayList<>();
-                        Double annualClassAverage;
-                        Double annualClassMin = null;
-                        Double annualClassMax = null;
-                        Double annualAverageStudent;
-                        for(Map.Entry<Integer, JsonArray> IdPeriodeNotesEntry : mapIdPeriodeNotes.entrySet()){
-                            StatMat statMatP = new StatMat();
-                            statMatP.setMapIdMatStatclass(IdPeriodeNotesEntry.getValue());
-                            Map<String, StatClass> mapMatieresStatClasseAndEleveP = statMatP.getMapIdMatStatclass();
-                            StatClass statClasseP = mapMatieresStatClasseAndEleveP.get(idMatiere);
+                    StatMat statMat = new StatMat();
+                    if(idPeriode != null) {
+                        statMat.setMapIdMatStatclass(listNotes);
+                        mapMatieresStatClasseAndEleve = statMat.getMapIdMatStatclass();
+                    } else { // notes order by periode
+                        Map<Integer, JsonArray> mapIdPeriodeNotes = getListNotesByPeriode(listNotes, false);
+                        if(!mapIdPeriodeNotes.isEmpty()) {
+                            for (int i = 0; i < idMatieres.size(); i++) {
+                                String idMatiere = idMatieres.getString(i);
+                                List<NoteDevoir> listAverageClass = new ArrayList<>();
+                                List<NoteDevoir> listAverageStudent = new ArrayList<>();
+                                Double annualClassAverage;
+                                Double annualClassMin = null;
+                                Double annualClassMax = null;
+                                Double annualAverageStudent;
+                                for(Map.Entry<Integer, JsonArray> IdPeriodeNotesEntry : mapIdPeriodeNotes.entrySet()){
+                                    StatMat statMatP = new StatMat();
+                                    statMatP.setMapIdMatStatclass(IdPeriodeNotesEntry.getValue());
+                                    Map<String, StatClass> mapMatieresStatClasseAndEleveP = statMatP.getMapIdMatStatclass();
+                                    StatClass statClasseP = mapMatieresStatClasseAndEleveP.get(idMatiere);
 
-                            if (statClasseP != null && !statClasseP.getMapEleveStat().isEmpty()) {
-                                listAverageClass.add(new NoteDevoir
-                                        (statClasseP.getAverageClass(), new Double(20), false, 1.0));
-                                if (annualClassMin == null) {
-                                    annualClassMin = statClasseP.getMinMaxClass(true);
-                                } else {
-                                    if (statClasseP.getMinMaxClass(true) < annualClassMin)
-                                        annualClassMin = statClasseP.getMinMaxClass(true);
+                                    if (statClasseP != null && !statClasseP.getMapEleveStat().isEmpty()) {
+                                        listAverageClass.add(new NoteDevoir
+                                                (statClasseP.getAverageClass(), new Double(20), false, 1.0));
+                                        if (annualClassMin == null) {
+                                            annualClassMin = statClasseP.getMinMaxClass(true);
+                                        } else {
+                                            if (statClasseP.getMinMaxClass(true) < annualClassMin)
+                                                annualClassMin = statClasseP.getMinMaxClass(true);
+                                        }
+                                        if (annualClassMax == null) {
+                                            annualClassMax = statClasseP.getMinMaxClass(false);
+                                        } else {
+                                            if (statClasseP.getMinMaxClass(false) > annualClassMax)
+                                                annualClassMax = statClasseP.getMinMaxClass(false);
+                                        }
+
+                                        if (statClasseP.getMoyenneEleve(idEleve) != null) {
+                                            listAverageStudent.add(new NoteDevoir
+                                                    (statClasseP.getMoyenneEleve(idEleve), new Double(20), false, 1.0));
+                                        }
+                                    }
                                 }
-                                if (annualClassMax == null) {
-                                    annualClassMax = statClasseP.getMinMaxClass(false);
-                                } else {
-                                    if (statClasseP.getMinMaxClass(false) > annualClassMax)
-                                        annualClassMax = statClasseP.getMinMaxClass(false);
-                                }
 
-                                if (statClasseP.getMoyenneEleve(idEleve) != null) {
-                                    listAverageStudent.add(new NoteDevoir
-                                            (statClasseP.getMoyenneEleve(idEleve), new Double(20), false, 1.0));
+                                StatEleve statEleveAnnual = new StatEleve();
+                                StatClass statClassAnnual = new StatClass();
+                                if( !listAverageClass.isEmpty() ){
+                                    if( !listAverageStudent.isEmpty() ) {
+                                        annualAverageStudent = utilsService.calculMoyenneParDiviseur(listAverageStudent,
+                                                false).getDouble("moyenne");
+                                        statEleveAnnual.setMoyenneAuto(annualAverageStudent);
+                                        statClassAnnual.getMapEleveStat().put(idEleve, statEleveAnnual);
+                                    }
+
+                                    annualClassAverage = utilsService.calculMoyenneParDiviseur(listAverageClass,
+                                            false).getDouble("moyenne");
+
+                                    statClassAnnual.setAverageClass(annualClassAverage);
+                                    statClassAnnual.setMax(annualClassMax);
+                                    statClassAnnual.setMin(annualClassMin);
+                                    mapMatieresStatClasseAndEleve.put(idMatiere, statClassAnnual);
                                 }
                             }
-                        }
 
-                        StatEleve statEleveAnnual = new StatEleve();
-                        StatClass statClassAnnual = new StatClass();
-                        if( !listAverageClass.isEmpty() ){
-                            if( !listAverageStudent.isEmpty() ) {
-                                annualAverageStudent = utilsService.calculMoyenneParDiviseur(listAverageStudent,
-                                        false).getDouble("moyenne");
-                                statEleveAnnual.setMoyenneAuto(annualAverageStudent);
-                                statClassAnnual.getMapEleveStat().put(idEleve, statEleveAnnual);
-                            }
-
-                            annualClassAverage = utilsService.calculMoyenneParDiviseur(listAverageClass,
-                                    false).getDouble("moyenne");
-
-                            statClassAnnual.setAverageClass(annualClassAverage);
-                            statClassAnnual.setMax(annualClassMax);
-                            statClassAnnual.setMin(annualClassMin);
-                            mapMatieresStatClasseAndEleve.put(idMatiere, statClassAnnual);
+                            statMat.setMapIdMatStatclass(mapMatieresStatClasseAndEleve);
+                        } else {
+                            statMat.setMapIdMatStatclass(listNotes);
+                            mapMatieresStatClasseAndEleve = statMat.getMapIdMatStatclass();
                         }
                     }
 
-                    statMat.setMapIdMatStatclass(mapMatieresStatClasseAndEleve);
-                } else {
-                    statMat.setMapIdMatStatclass(listNotes);
-                    mapMatieresStatClasseAndEleve = statMat.getMapIdMatStatclass();
-                }
-            }
-
-            // 6. On récupère tous les libelles des matières de l'établissement et on fait correspondre
-            // aux résultats par idMatière
-            linkIdSubjectToLibelle(idEleve, idPeriode, getMaxByItem(matieresCompNotes, tableauDeConversionFuture.result()),
-                    getMaxByItem(matieresCompNotesEleve, tableauDeConversionFuture.result()), matieresNotes, matieresNotesEleve,
-                    mapMatieresStatClasseAndEleve, idMatieres, subjectF.result(), handler);
-        });
+                    // 6. On récupère tous les libelles des matières de l'établissement et on fait correspondre
+                    // aux résultats par idMatière
+                    linkIdSubjectToLibelle(idEleve, idPeriode, getMaxOrAvgByItem(matieresCompNotes, tableauDeConversionFuture.result(),isAvgSkillpromiseResult ),
+                            getMaxOrAvgByItem(matieresCompNotesEleve, tableauDeConversionFuture.result(),isAvgSkillpromiseResult ), matieresNotes, matieresNotesEleve,
+                            mapMatieresStatClasseAndEleve, idMatieres, subjectF.result(), handler);
+                }))
+                .onFailure(err ->{
+                    String message = "[getReleveDataForGraph] " + err.getMessage();
+                    log.error(message);
+                    handler.handle(new Either.Left<>(message));
+                });
     }
 
     public void getDataGraphDomaine(final String idEleve, JsonArray groupIds, final String idEtablissement ,
@@ -3651,21 +3654,31 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         competenceNoteService.getConversionNoteCompetence(idEtablissement, idClasse,tableauEvent ->
                 formate(tableauDeConversionFuture, tableauEvent));
 
+        Future<Boolean> isAvgSkillFuture = structureOptionsService.isAverageSkills(idEtablissement);
+
+        isAvgSkillFuture
+                .onSuccess(isAvgSkillpromiseResult -> {
+                    CompositeFuture.all(compNotesFuture, domainesCycleFuture,tableauDeConversionFuture).setHandler(event -> {
+                        if (event.succeeded()) {
+                            handler.handle(new Either.Right<>(linkCompNoteToLibelle(domainesCycleFuture.result(),
+                                    compNotesFuture.result(), tableauDeConversionFuture.result(), idEleve, isAvgSkillpromiseResult)));
+                        } else {
+                            String message = event.cause().getMessage();
+                            handler.handle(new Either.Left<>(message));
+                            log.error(message);
+                        }
+                    });
+                })
+                .onFailure(err ->{
+                    handler.handle(new Either.Left<>(err.getMessage()));
+                    log.error(err.getMessage());
+                });
         // 4. On Lie les compétences-Notes à leur libellé
-        CompositeFuture.all(compNotesFuture, domainesCycleFuture,tableauDeConversionFuture).setHandler(event -> {
-            if (event.succeeded()) {
-                handler.handle(new Either.Right<>(linkCompNoteToLibelle(domainesCycleFuture.result(),
-                        compNotesFuture.result(), tableauDeConversionFuture.result(), idEleve)));
-            } else {
-                String message = event.cause().getMessage();
-                handler.handle(new Either.Left<>(message));
-                log.error(message);
-            }
-        });
+
 
     }
 
-    private JsonArray linkCompNoteToLibelle(JsonArray domaines, JsonArray compNotes, JsonArray tableauConversion, String idEleve) {
+    private JsonArray linkCompNoteToLibelle(JsonArray domaines, JsonArray compNotes, JsonArray tableauConversion, String idEleve, boolean isAvgSkill) {
 
         Map<Long,JsonObject> domainesMap = new HashMap<>();
         JsonArray res = new JsonArray();
@@ -3698,8 +3711,8 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
             JsonArray competencesNotes =
                     (data!=null)?data.getJsonArray("competencesNotes") : new JsonArray();
             if (data!= null) {
-                res.add(domaine.put("competencesNotes",   getMaxByItemDomaine(competencesNotes,tableauConversion))
-                        .put("competencesNotesEleve", getMaxByItemDomaine(competencesNotesEleve,tableauConversion)));
+                res.add(domaine.put("competencesNotes",   getMaxOrAvgByItemDomaine(competencesNotes,tableauConversion, isAvgSkill))
+                        .put("competencesNotesEleve", getMaxOrAvgByItemDomaine(competencesNotesEleve,tableauConversion, isAvgSkill)));
             }
         }
         return res;
@@ -3750,15 +3763,15 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         return mapIdPeriodeListeNotes;
     }
     // Permet de Calculer le Max des Niveaux Atteints par Items regroupés par Matière
-    private Map<String,JsonArray> getMaxByItem(Map<String,JsonArray> mapData, JsonArray tableauConversion){
+    private Map<String,JsonArray> getMaxOrAvgByItem(Map<String, JsonArray> mapData, JsonArray tableauConversion, boolean isAvgSkill){
         Map<String,JsonArray> result = new HashMap<>();
 
         for (Map.Entry<String,JsonArray> entry: mapData.entrySet()) {
             String idEntry = entry.getKey();
             JsonArray currentEntry = entry.getValue();
-            Map<String, JsonObject> maxComp = calculMaxCompNoteItem(currentEntry, tableauConversion,true);
+            Map<String, JsonObject> maxOrAvgComp = calculMaxOrAvgCompNoteItem(currentEntry, tableauConversion,true, isAvgSkill);
             result.put(idEntry, new JsonArray());
-            for (Map.Entry<String,JsonObject> max: maxComp.entrySet()) {
+            for (Map.Entry<String,JsonObject> max: maxOrAvgComp.entrySet()) {
                 result.get(idEntry).add(max.getValue());
             }
         }
@@ -3766,21 +3779,22 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
     }
 
     // Permet de Calculer le Max des Niveaux Atteints par Items regroupés par Domaine
-    private JsonArray getMaxByItemDomaine(JsonArray compNotes,JsonArray tableauConversion){
+    private JsonArray getMaxOrAvgByItemDomaine(JsonArray compNotes, JsonArray tableauConversion, boolean isAvgSkill){
         JsonArray result = new JsonArray();
 
-        Map<String, JsonObject> maxCompNote = calculMaxCompNoteItem(compNotes, tableauConversion,true);
-        for (Map.Entry<String,JsonObject> max: maxCompNote.entrySet()) {
+        Map<String, JsonObject> maxOrAvgCompNote = calculMaxOrAvgCompNoteItem(compNotes, tableauConversion,true, isAvgSkill);
+        for (Map.Entry<String,JsonObject> max: maxOrAvgCompNote.entrySet()) {
             result.add(max.getValue());
         }
 
         return result;
     }
 
-    private Map<String, JsonObject> calculMaxCompNoteItem (JsonArray compNotes, JsonArray tableauConversion, Boolean takeNivFinal) {
+    private Map<String, JsonObject> calculMaxOrAvgCompNoteItem(JsonArray compNotes, JsonArray tableauConversion, Boolean takeNivFinal, boolean isAvg) {
         Map<String, JsonObject> maxComp = new HashMap<>();
         Map<String, List<JsonObject>> groupByStudent = new HashMap<>();
         JsonArray clone = compNotes.copy();
+
         //On groupe les items de compétences par élève
         for (int i = 0; i < clone.size(); i++) {
             JsonObject compNote = clone.getJsonObject(i);
@@ -3808,31 +3822,42 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                     }
                     groupByMat.get(compNote.getString("id_matiere")).add(compNote);
                 }
-                List<JsonObject> listSameCompMaxMat = new ArrayList<>();
-                //On récupère les maxs de chaque matière
-                for (Map.Entry<String, List<JsonObject>> listMat : groupByMat.entrySet()) {
-                    List<JsonObject> listSameMatComp = listMat.getValue();
-                    Long max = listSameMatComp.get(0).getLong("evaluation");
-                    JsonObject JsonObjectToAdd = listSameMatComp.get(0);
-                    for (JsonObject compNoteTemp : listSameMatComp) {
-                        Long evaluation = compNoteTemp.getLong("evaluation");
-                        Long niveauFinal = compNoteTemp.getLong("niveau_final");
-                        Long niveauFinalAnnuel = compNoteTemp.getLong("niveau_final_annuel");
-                        Long valueToTake;
-                        if (takeNivFinal) {
-                            if(niveauFinalAnnuel != null)
-                                valueToTake = niveauFinalAnnuel;
-                            else
-                                valueToTake = (niveauFinal != null) ? niveauFinal : evaluation;
-                        }else{
-                            valueToTake = evaluation;
-                        }
-                        if (valueToTake != null && valueToTake > max) {
-                            max = valueToTake;
-                            JsonObjectToAdd = compNoteTemp;
-                        }
+                List<JsonObject> listSameCompMaxOrAvgMat = new ArrayList<>();
+
+                if(isAvg){ // moyenne de chaque competence par matiere
+                    for (Map.Entry<String, List<JsonObject>> listMat : groupByMat.entrySet()) {
+                        List<JsonObject> listSameMatComp = listMat.getValue();
+                        JsonObject compMat = listSameMatComp.get(0);
+                        float moyenneComp = calculMoyCompetence(listSameMatComp, takeNivFinal);
+                        compMat.put("evaluation", moyenneComp);
+                        listSameCompMaxOrAvgMat.add(compMat);
                     }
-                    listSameCompMaxMat.add(JsonObjectToAdd);
+
+                }else {  //On récupère les maxs de chaque matière
+                    for (Map.Entry<String, List<JsonObject>> listMat : groupByMat.entrySet()) {
+                        List<JsonObject> listSameMatComp = listMat.getValue();
+                        Long max = listSameMatComp.get(0).getLong("evaluation");
+                        JsonObject JsonObjectToAdd = listSameMatComp.get(0);
+                        for (JsonObject compNoteTemp : listSameMatComp) {
+                            Long evaluation = compNoteTemp.getLong("evaluation");
+                            Long niveauFinal = compNoteTemp.getLong("niveau_final");
+                            Long niveauFinalAnnuel = compNoteTemp.getLong("niveau_final_annuel");
+                            Long valueToTake;
+                            if (takeNivFinal) {
+                                if (niveauFinalAnnuel != null)
+                                    valueToTake = niveauFinalAnnuel;
+                                else
+                                    valueToTake = (niveauFinal != null) ? niveauFinal : evaluation;
+                            } else {
+                                valueToTake = evaluation;
+                            }
+                            if (valueToTake != null && valueToTake > max) {
+                                max = valueToTake;
+                                JsonObjectToAdd = compNoteTemp;
+                            }
+                        }
+                        listSameCompMaxOrAvgMat.add(JsonObjectToAdd);
+                    }
                 }
                 //Et on fait la moyenne des maxs de chaque matières dans l'item de compétences
                 JsonObject compNote = listSameComp.get(0);
@@ -3843,37 +3868,43 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
 
                 String idItem = (idCompetence != null) ? idCompetence.toString() : "null";
                 idItem += idEleve;
-                float sum = 0L;
-                float nbrofMat = 0L;
-                for (JsonObject compNoteTemp : listSameCompMaxMat) {
-                    Long evaluation = compNoteTemp.getLong("evaluation");
-                    Long niveauFinal = compNoteTemp.getLong("niveau_final");
-                    Long niveauFinalAnnuel = compNoteTemp.getLong("niveau_final_annuel");
-                    Long valueToTake;
-                    if (takeNivFinal) {
-                        if(niveauFinalAnnuel != null)
-                            valueToTake = niveauFinalAnnuel;
-                        else
-                            valueToTake = (niveauFinal != null) ? niveauFinal : evaluation;
-                    }else{
-                        valueToTake = evaluation;
-                    }
-                    if (valueToTake != null) {
-                        sum += valueToTake;
-                        nbrofMat++;
-                    }
-                }
-                float moyenneToSend;
-                if (nbrofMat != 0)
-                    moyenneToSend = sum / nbrofMat;
-                else
-                    moyenneToSend = 1f;
+                float moyenneToSend = calculMoyCompetence(listSameCompMaxOrAvgMat,takeNivFinal);
                 int moyenneConverted = utilsService.getPositionnementValue(moyenneToSend+1, tableauConversion)-1;
-                compNote.put("evaluation", moyenneConverted).put("niveau_final", moyenneConverted);
+                //evaluations pour le calcul du positionnement sans la convertion et evaluationGraph converti pour les proportions du graphe
+                compNote.put("evaluation", moyenneToSend).put("niveau_final", moyenneToSend).put("evaluationGraph", moyenneConverted);
                 maxComp.put(idItem, compNote);
             }
         }
         return maxComp;
+    }
+
+    private float calculMoyCompetence(List<JsonObject> listSameComp, Boolean  takeNivFinal){
+        float avg;
+        float sum = 0L;
+        float nbrofElt = 0L;
+        for (JsonObject compNoteTemp : listSameComp) {
+            Float evaluation = compNoteTemp.getFloat("evaluation");
+            Float niveauFinal = compNoteTemp.getFloat("niveau_final");
+            Float niveauFinalAnnuel = compNoteTemp.getFloat("niveau_final_annuel");
+            Float valueToTake;
+            if (Boolean.TRUE.equals(takeNivFinal)){
+                if(niveauFinalAnnuel != null)
+                    valueToTake = niveauFinalAnnuel;
+                else
+                    valueToTake = (niveauFinal != null) ? niveauFinal : evaluation;
+            }else{
+                valueToTake = evaluation;
+            }
+            if (valueToTake != null) {
+                sum += valueToTake;
+                nbrofElt++;
+            }
+        }
+        if (nbrofElt != 0)
+            avg = sum / nbrofElt ;
+        else
+            avg = -2f;
+        return avg;
     }
 
     private void linkIdSubjectToLibelle(String idEleve, Long idPeriode, Map<String, JsonArray> matieresCompNotes,
@@ -4073,6 +4104,9 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                 formate(tableauDeConversionFuture, tableauEvent));
         detailsFuture.add(tableauDeConversionFuture);
 
+        Future<Boolean> isAvgSkillFuture = structureOptionsService.isAverageSkills(idEtablissement);
+        detailsFuture.add(isAvgSkillFuture);
+
         CompositeFuture.all(detailsFuture).setHandler(event -> {
             if(event.failed()){
                 String error = event.cause().getMessage();
@@ -4088,7 +4122,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
             // Calcul des positionements
             JsonArray listCompNotes = listCompNotesF.result();
             calculPositionnementAutoByEleveByMatiere(listCompNotes, result,false, tableauDeConversionFuture.result(),
-                    null ,null );
+                    null ,null, isAvgSkillFuture.result());
 
             // Calcul des moyennes par période pour la classe
             JsonArray moyFinalesEleves = moyFinalesElevesF.result();

--- a/src/main/java/fr/openent/competences/service/impl/DefaultStructureOptions.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultStructureOptions.java
@@ -4,7 +4,9 @@ import fr.openent.competences.Competences;
 import fr.openent.competences.constants.Field;
 import fr.openent.competences.service.StructureOptionsService;
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.service.impl.SqlCrudService;
@@ -44,4 +46,22 @@ public class DefaultStructureOptions extends SqlCrudService implements Structure
         Sql.getInstance().prepared(query.toString(), params, Competences.DELIVERY_OPTIONS,
                 validUniqueResultHandler(handler));
     }
+
+    /**
+     * @param structureId structure id
+     * @return response
+     */
+    @Override
+    public Future<Boolean> isAverageSkills (String structureId) {
+
+        Promise<Boolean> promise = Promise.promise();
+        getIsAverageSkills(structureId, event -> {
+            if(event.isRight())
+                promise.complete(event.right().getValue().getBoolean(Field.IS_AVERAGE_SKILLS)); // pour "is_average_skills"
+            else
+                promise.fail(event.left().getValue());
+        });
+        return promise.future();
+    }
+
 }

--- a/src/main/java/fr/openent/competences/service/impl/DefaultStructureOptions.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultStructureOptions.java
@@ -1,0 +1,47 @@
+package fr.openent.competences.service.impl;
+
+import fr.openent.competences.Competences;
+import fr.openent.competences.constants.Field;
+import fr.openent.competences.service.StructureOptionsService;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.service.impl.SqlCrudService;
+import org.entcore.common.sql.Sql;
+import org.entcore.common.sql.SqlResult;
+
+import static org.entcore.common.sql.SqlResult.validUniqueResultHandler;
+
+public class DefaultStructureOptions extends SqlCrudService implements StructureOptionsService {
+
+    public DefaultStructureOptions () {
+        super(Competences.EVAL_SCHEMA, Field.STRUTUCTURE_OPTIONS);
+    }
+
+    @Override
+    public void createOrUpdateIsAverageSkills (JsonObject body, Handler<Either<String, JsonObject>> handler) {
+        final String structureId = body.getString(Field.STRUCTUREID);
+        final boolean isAverageSkills = body.getBoolean(Field.ISSKILLAVERAGE);
+        StringBuilder query = new StringBuilder();
+        query.append("INSERT INTO ").append(this.resourceTable)
+                .append("(id_structure, is_average_skills)")
+                .append("VALUES (?, ?)")
+                .append("ON CONFLICT (id_structure) DO UPDATE SET is_average_skills = ? ");
+
+        JsonArray values = new JsonArray().add(structureId).add(isAverageSkills).add(isAverageSkills);
+
+        Sql.getInstance().prepared(query.toString(), values, SqlResult.validUniqueResultHandler(handler));
+    }
+
+    @Override
+    public void getIsAverageSkills (String structureId, Handler<Either<String, JsonObject>> handler) {
+        StringBuilder query = new StringBuilder();
+        query.append("SELECT EXISTS (SELECT is_average_skills FROM ").append(this.resourceTable)
+                .append(" WHERE id_structure = ? AND is_average_skills = TRUE) AS is_average_skills ");
+        JsonArray params = new JsonArray().add(structureId);
+
+        Sql.getInstance().prepared(query.toString(), params, Competences.DELIVERY_OPTIONS,
+                validUniqueResultHandler(handler));
+    }
+}

--- a/src/main/java/fr/openent/competences/service/impl/DefaultTransitionService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultTransitionService.java
@@ -18,6 +18,7 @@
 package fr.openent.competences.service.impl;
 
 import fr.openent.competences.Competences;
+import fr.openent.competences.service.StructureOptionsService;
 import fr.openent.competences.service.TransitionService;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Handler;
@@ -42,8 +43,10 @@ import static org.entcore.common.sql.SqlResult.validResultHandler;
 public class DefaultTransitionService extends SqlCrudService implements TransitionService{
     protected static final Logger log = LoggerFactory.getLogger(DefaultTransitionService.class);
     private final Neo4j neo4j = Neo4j.getInstance();
+    private StructureOptionsService structureOptionsService;
     public DefaultTransitionService() {
         super(Competences.COMPETENCES_SCHEMA, Competences.TRANSITION_TABLE);
+        structureOptionsService = new DefaultStructureOptions();
     }
 
     @Override
@@ -249,8 +252,6 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
     }
 
     private static final String _id_user_transition_annee = "id-user-transition-annee";
-    private static final String key_username_user_transition_annee ="transition.bilan.annee";
-    private static final String key_libelle_classe_transition_annee = "transition.bilan.annee.classe";
 
     /**
      * * Effectue la transistion d'année de l'établissement actif passé en paramètre
@@ -266,29 +267,42 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
                                           String idStructureATraiter, Handler<Either<String, JsonArray>> handler) {
 
         log.info("DEBUT : transactions pour la transition année id Etablissement [transitionAnneeStructure] : " + idStructureATraiter);
-        if (vListIdsGroupesATraiter != null && vListIdsGroupesATraiter.size()>0) {
+        if (vListIdsGroupesATraiter != null && vListIdsGroupesATraiter.size() > 0) {
             //BCP de logs, illisible
             //log.info("INFO : transactions pour la transition année vListIdsGroupesATraiter  : " + vListIdsGroupesATraiter.toString());
         } else {
             log.warn("WARN : transactions pour la transition année vListIdsGroupesATraiter : Aucun groupe ");
         }
-        JsonArray statements = new fr.wseduc.webutils.collections.JsonArray();
-        
-        // Suppresssion : Conservation des  compétences max par l'élève, suppresion des devoirs
-        manageDevoirsAndCompetences(idStructureATraiter, vMapGroupesATraiter, vMapGroupesIdsDevoirATraiter,
-                classeIdsEleves, statements);
 
-        // Suppresion des notes.users, rel_group_cycle
-        deleteUsersGroups(statements);
+        structureOptionsService.getIsAverageSkills(idStructureATraiter, responseCalculate -> {
 
-        // Transition pour l'établissement effectué
-        JsonArray valuesTransition = new fr.wseduc.webutils.collections.JsonArray();
-        valuesTransition.add(idStructureATraiter);
-        String queryInsertTransition ="INSERT INTO " + Competences.COMPETENCES_SCHEMA + ".transition(id_etablissement) VALUES (?)";
-        statements.add(new JsonObject().put("statement", queryInsertTransition).put("values", valuesTransition).put("action", "prepared"));
+            if (responseCalculate.isLeft()) {
+                log.error("[DefaultTransitionService] getIsAverageSkills idStructure : "
+                        + idStructureATraiter + " " + responseCalculate.left().getValue());
+                handler.handle(new Either.Left<>("[DefaultTransitionService] getIsAverageSkills idStructure : "
+                        + idStructureATraiter));
+                return;
+            }
+            Boolean isSkillAverage = responseCalculate.right().getValue().getBoolean("is_average_skills");
 
-        Sql.getInstance().transaction(statements,new DeliveryOptions().setSendTimeout(TRANSITION_CONFIG.getInteger("timeout-transaction") * 1000L),
-                SqlResult.validResultHandler(handler));
+            JsonArray statements = new fr.wseduc.webutils.collections.JsonArray();
+
+            // Suppresssion : Conservation des  compétences max par l'élève, suppresion des devoirs
+            manageDevoirsAndCompetences(idStructureATraiter, vMapGroupesATraiter, vMapGroupesIdsDevoirATraiter,
+                    classeIdsEleves, isSkillAverage, statements);
+
+            // Suppresion des notes.users, rel_group_cycle
+            deleteUsersGroups(statements);
+
+            // Transition pour l'établissement effectué
+            JsonArray valuesTransition = new fr.wseduc.webutils.collections.JsonArray();
+            valuesTransition.add(idStructureATraiter);
+            String queryInsertTransition = "INSERT INTO " + Competences.COMPETENCES_SCHEMA + ".transition(id_etablissement) VALUES (?)";
+            statements.add(new JsonObject().put("statement", queryInsertTransition).put("values", valuesTransition).put("action", "prepared"));
+
+            Sql.getInstance().transaction(statements, new DeliveryOptions().setSendTimeout(TRANSITION_CONFIG.getInteger("timeout-transaction") * 1000L),
+                    SqlResult.validResultHandler(handler));
+        });
     }
 
     /**
@@ -327,7 +341,8 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
      */
     private void manageDevoirsAndCompetences( String idStructureATraiter, Map<String,String> vMapGroupesATraiter,
                                               Map<String, Long> vMapGroupesIdsDevoirATraiter, Map<String,List<String>> classeIdsEleves,
-                                              JsonArray statements) {
+                                              Boolean isSkillAverage, JsonArray statements) {
+
         JsonArray values;// Ajout de l'utilisateur pour la transition année
         String username = "NC";
         String classname = "Bilan Année classe : ";
@@ -372,19 +387,21 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
             if(null != vListEleves && vListEleves.size() > 0) {
                 JsonArray valuesMaxCompetence = new fr.wseduc.webutils.collections.JsonArray();
 
-
-                String queryMaxCompNoteNiveauFinalByPeriode = "(SELECT competences_notes.id_competence, " +
+                String queryMaxOrAvgCompNoteNiveauFinalByPeriode = "(SELECT competences_notes.id_competence, " +
                         "competences_notes.id_eleve, devoirs.id_periode, devoirs.id_matiere, CASE " +
 
                         "WHEN competence_niveau_final.id_eleve IS NULL AND competence_niveau_final_annuel.id_eleve IS NULL" +
-                        "   THEN MAX(competences_notes.evaluation) " +
+                        "   THEN ";
+                queryMaxOrAvgCompNoteNiveauFinalByPeriode += (Boolean.TRUE.equals(isSkillAverage)) ?
+                        "ROUND(AVG(competences_notes.evaluation), 2) "
+                        : "MAX(competences_notes.evaluation) " ;
 
-                        "WHEN competence_niveau_final.id_eleve IS NOT NULL AND competence_niveau_final_annuel.id_eleve IS NULL" +
+                queryMaxOrAvgCompNoteNiveauFinalByPeriode += "WHEN competence_niveau_final.id_eleve IS NOT NULL AND competence_niveau_final_annuel.id_eleve IS NULL" +
                         "   THEN MAX(competence_niveau_final.niveau_final) " +
 
                         "ELSE MAX(competence_niveau_final_annuel.niveau_final) " +
 
-                        "END AS max_comp "+
+                        "END AS comp_note_by_subject_period "+
                         "FROM " + Competences.COMPETENCES_SCHEMA + ".competences_notes " +
                         "INNER JOIN " + Competences.COMPETENCES_SCHEMA + ".devoirs ON devoirs.id = competences_notes.id_devoir " +
 
@@ -404,11 +421,14 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
                         "GROUP BY competences_notes.id_competence, competences_notes.id_eleve, competence_niveau_final.id_eleve," +
                         "competence_niveau_final_annuel.id_eleve, devoirs.id_periode, devoirs.id_matiere)";
 
-                String queryMaxCompNoteMat = "(SELECT id_competence, MAX(max_comp), id_eleve, id_matiere FROM " + queryMaxCompNoteNiveauFinalByPeriode +
-                        " AS max_mat GROUP BY id_competence, id_eleve, id_matiere)";
+                String queryMaxOrAvgCompNoteMat = "(SELECT id_competence, ";
+                queryMaxOrAvgCompNoteMat += (Boolean.TRUE.equals(isSkillAverage)) ? "ROUND(AVG(comp_note_by_subject_period), 2) ":
+                        "MAX(comp_note_by_subject_period) ";
+                queryMaxOrAvgCompNoteMat +=  "AS comp_note_by_subject, id_eleve, id_matiere FROM " + queryMaxOrAvgCompNoteNiveauFinalByPeriode +
+                        " AS max_or_avg_mat GROUP BY id_competence, id_eleve, id_matiere)";
 
-                String queryAverageMaxCompNoteMat = "(SELECT id_competence, ROUND(AVG(max)+1,2) AS round, id_eleve FROM " + queryMaxCompNoteMat +
-                        " AS avg GROUP BY id_competence, id_eleve)";
+                String queryAverageCompNoteMat = "(SELECT id_competence, ROUND(AVG(comp_note_by_subject)+1,2) AS round, id_eleve FROM "
+                        + queryMaxOrAvgCompNoteMat + " AS avg GROUP BY id_competence, id_eleve)";
 
                 String queryConversionAverage = "WITH table_conversion as (SELECT valmin, valmax, ordre FROM notes.niveau_competences AS niv " +
                         "INNER JOIN  notes.echelle_conversion_niv_note AS echelle ON niv.id = echelle.id_niveau " +
@@ -424,7 +444,12 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
                         "WHEN round >= (SELECT valmin FROM table_conversion where ordre = 4) AND round <= (SELECT valmax FROM table_conversion where ordre = 4) " +
                         "THEN 3 " +
                         "END " +
-                        ",'" + _id_user_transition_annee + "', id_eleve FROM " + queryAverageMaxCompNoteMat + "as conversion_max_mats GROUP BY id_competence, id_eleve, round";
+                        ",'" + _id_user_transition_annee + "', id_eleve FROM " + queryAverageCompNoteMat + "as conversion_max_mats GROUP BY id_competence, id_eleve, round";
+
+
+
+
+
 
                 valuesMaxCompetence.add(idClasse).add(idStructureATraiter);
                 for (String idEleve : vListEleves) {

--- a/src/main/java/fr/openent/competences/service/impl/DefaultTransitionService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultTransitionService.java
@@ -18,6 +18,7 @@
 package fr.openent.competences.service.impl;
 
 import fr.openent.competences.Competences;
+import fr.openent.competences.constants.Field;
 import fr.openent.competences.service.StructureOptionsService;
 import fr.openent.competences.service.TransitionService;
 import fr.wseduc.webutils.Either;
@@ -283,7 +284,7 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
                         + idStructureATraiter));
                 return;
             }
-            Boolean isSkillAverage = responseCalculate.right().getValue().getBoolean("is_average_skills");
+            Boolean isSkillAverage = responseCalculate.right().getValue().getBoolean(Field.IS_AVERAGE_SKILLS);
 
             JsonArray statements = new fr.wseduc.webutils.collections.JsonArray();
 

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -181,7 +181,7 @@
   "evaluations.remplacement.add":"Ajouter un remplacement",
   "evaluations.remplacement.titulaire":"Titulaire",
   "evaluations.remplacement.remplacant":"Remplaçant",
-  "evaluations.level": "Niveau de maitrise",
+  "evaluations.level": "Niveau de maitrise et calcul du niveau",
   "evaluations.remplacement.debut":"Début",
   "evaluations.remplacement.fin":"Fin",
   "evaluations.remplacement.ajouter":"Ajouter le remplacement",
@@ -823,5 +823,11 @@
   "competence.createCompetence.domaine" : "Domaines",
   "competence.createCompetence.success": "Nouvel item de compétence créé.",
   "competence.createCompetence.error": "Erreur lors de la création de l'item.",
-  "competence.createCompetence.error.unautorize": "Désolé, vous n'êtes pas autorisé à créer des items."
+  "competence.createCompetence.error.unautorize": "Désolé, vous n'êtes pas autorisé à créer des items.",
+  "competence.struture.option.default.sentence": "Par défault, si un item est évalué sur plusieurs devoirs, c'est le niveau maximum qui est retenu.",
+  "competence.struture.option.is.average.skills": "Calculer et utiliser la moyenne des niveaux pour chaque item de compétences",
+  "viescolaire.confirmation.updateSchoolYear": "Vous allez changer les dates de l'année scolaire.Des applications pourraient être impactées par ce changement. Voulez-vous continuer ?",
+  "competence.structure.option.title.calculate.level.skills": "Calcul du niveau des items de compétences",
+  "competences.structure.options.error.get": "une erreur est survenue lors de la récupération de l'option du calcul des compétences",
+  "competences.structure.options.error.save": "une erreur est survenue lors de la sauvegarde du calcul des compétences"
 }

--- a/src/main/resources/jsonschema/eval_createOrUpdateStructureOptionIsAverageSkills.json
+++ b/src/main/resources/jsonschema/eval_createOrUpdateStructureOptionIsAverageSkills.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "structureId": {
+      "type": "string"
+    },
+    "isSkillAverage": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "structureId",
+    "isSkillAverage"
+  ]
+}

--- a/src/main/resources/public/sass/global/_competences-specifics.scss
+++ b/src/main/resources/public/sass/global/_competences-specifics.scss
@@ -27,6 +27,7 @@
 @import "specifics/_tableNote";
 @import "specifics/_materialize";
 @import "specifics/proportionSuiviCompetence";
+@import "sniplets/switch";
 @font-face {
   font-family: 'material-icons';
   src: url('/competences/public/font/material-design/fonts/materialdesignicons-webfont.eot');

--- a/src/main/resources/public/sass/global/sniplets/_switch.scss
+++ b/src/main/resources/public/sass/global/sniplets/_switch.scss
@@ -1,0 +1,55 @@
+.switch {
+
+  .tick {
+    width: 40px;
+    height: 12px;
+    display: block;
+    border-radius: 10px;
+    background: $neutral-grey ;
+    position: relative;
+    overflow: visible;
+    margin: 5px;
+
+    &:before {
+      content: ' ';
+      width: 20px !important;
+      height: 20px !important;
+      left: 0 ;
+      display: block;
+      background: $white ;
+      border-radius: 50%;
+      position: absolute;
+      top: -4px;
+      box-shadow: 0 1px 1px $shadow;
+      margin-right: 0;
+      margin-top: 0 !important;
+      border: none;
+    }
+  }
+
+  input[type=checkbox]:checked + .tick {
+    background: $primary-light;
+    &:before {
+      left: 20px;
+      background: $primary-dark ;
+    }
+  }
+
+  input[type=checkbox]:disabled + .tick {
+    background: $disabled-color;
+
+    &:before {
+      background: $disabled-color;
+    }
+  }
+
+  input[type=checkbox]:disabled:checked + .tick {
+    background: $primary-lighter;
+
+    &:before {
+      background: $primary-lighter;
+    }
+  }
+
+}
+

--- a/src/main/resources/public/template/behaviours/sniplet-structure-option-is-average-skills.html
+++ b/src/main/resources/public/template/behaviours/sniplet-structure-option-is-average-skills.html
@@ -1,0 +1,13 @@
+<div class="inline-block">
+    <div>
+        <p><i18n>competence.struture.option.default.sentence</i18n></p>
+        <div>
+            <span class="cell"><i18n>competence.struture.option.is.average.skills</i18n></span>
+            <label class="switch">
+                <input type="checkbox" ng-model="vm.option.isSkillAverage" ng-change ="vm.saveOptionIsAverageSkills()" ng-disabled="ngDisabled"/>
+                <span class="tick cell"></span>
+            </label>
+
+        </div>
+    </div>
+</div>

--- a/src/main/resources/public/ts/behaviours.ts
+++ b/src/main/resources/public/ts/behaviours.ts
@@ -28,6 +28,7 @@ import {paramImportCSV} from "./sniplets/param_import_csv";
 import {programElements} from "./sniplets/programsElement";
 import {orderShowSubject} from "./sniplets/orderShowSubject";
 import {notesMementoWidget} from "./sniplets/memento"
+import {structureOptionIsAverageSkills} from "./sniplets/structure-option-is-average-skills";
 
 Behaviours.register('competences', {
     rights: {
@@ -63,6 +64,7 @@ Behaviours.register('competences', {
     loadResources: async function (callback) {
     },
     sniplets: {
+        'structure-option-is-average-skills' :  structureOptionIsAverageSkills,
         visibilitymoyBFC: visibilitymoyBFC,
         visibilityDNB: visibilityDNB,
         itemsCompetences: itemsCompetences,

--- a/src/main/resources/public/ts/controllers/eval_suivi_competences_classe_ctl.ts
+++ b/src/main/resources/public/ts/controllers/eval_suivi_competences_classe_ctl.ts
@@ -30,6 +30,7 @@ import {FilterNotEvaluated, FilterNotEvaluatedEnseignement} from "../utils/filte
 import {updateColorAndLetterForSkills, updateNiveau} from "../models/common/Personnalisation";
 import {BilanPeriodique} from "../models/teacher/BilanPeriodique";
 import {getTitulairesForRemplacantsCoEnseignant, translate} from "../utils/teacher";
+import {structureOptionsService} from "../services";
 
 declare let _: any;
 
@@ -152,24 +153,28 @@ export let evalSuiviCompetenceClasseCtl = ng.controller('EvalSuiviCompetenceClas
             updateNiveau(usePerso, $scope);
         };
 
-        $scope.getMaxEvaluations = function (idEleve) {
+        $scope.getMaxOrAverageEvaluations = (idEleve) : number => {
             if ($scope.detailCompetence === undefined
                 || $scope.detailCompetence === null) {
                 return;
             }
             if ($scope.suiviFilter === undefined) $scope.initFilterMine();
-            let evaluations = _.where($scope.detailCompetence.competencesEvaluations, {id_eleve: idEleve});
+            let evals: Array<object>;
+            evals = _.where($scope.detailCompetence.competencesEvaluations, {id_eleve: idEleve});
             if($scope.suiviFilter.mine == 'true') {
-                evaluations = _.filter(evaluations,evaluation => {
+                evals = _.filter(evals, (evaluation : any) => {
                     return _.findWhere($scope.listTeacher,{id_enseignant : evaluation.owner, id_matiere : evaluation.id_matiere});
                 });
             }
-            if (evaluations.length > 0) {
+            if (evals.length > 0) {
                 // filtre sur les competences prises dans le calcul
-                evaluations = _.filter(evaluations, function (competence) {
+                evals = _.filter(evals, (competence: any) => {
                     return !competence.formative; // la competence doit être reliée à un devoir ayant un type non "formative"
                 });
-                return Utils.getNiveauMaxOfListEval(evaluations,$scope.suiviCompetence.tableauConversion,false,
+                return (evaluations.structure.options.isSkillAverage) ?
+                    Utils.getNiveauMoyOfListEval(evals,$scope.suiviCompetence.tableauConversion, false,
+                        $scope.search.periode.id === null) :
+                    Utils.getNiveauMaxOfListEval(evals,$scope.suiviCompetence.tableauConversion, false,
                     $scope.search.periode.id === null);
             }
         };
@@ -178,8 +183,8 @@ export let evalSuiviCompetenceClasseCtl = ng.controller('EvalSuiviCompetenceClas
          * @param eleveId identifiant de l'élève
          * @returns {String} Nom de la classe
          */
-        $scope.getEvaluationResultColor = function (eleveId) {
-            let moyenneMaxMats = $scope.getMaxEvaluations(eleveId);
+        $scope.getEvaluationResultColor =  function (eleveId) {
+            let moyenneMaxMats = $scope.getMaxOrAverageEvaluations(eleveId);
             if (moyenneMaxMats !== -Infinity) {
                 return $scope.mapCouleurs[moyenneMaxMats];
             }
@@ -189,8 +194,8 @@ export let evalSuiviCompetenceClasseCtl = ng.controller('EvalSuiviCompetenceClas
             return eleve.isEvaluable($scope.search.periode);
         };
 
-        $scope.FilterColor = function (item) {
-            let moyenneMaxMats = $scope.getMaxEvaluations(item.id);
+        $scope.FilterColor = (item) : number => {
+            let moyenneMaxMats = $scope.getMaxOrAverageEvaluations(item.id);
             if (moyenneMaxMats === undefined) {
                 return;
             }

--- a/src/main/resources/public/ts/controllers/eval_suivi_eleve_ctl.ts
+++ b/src/main/resources/public/ts/controllers/eval_suivi_eleve_ctl.ts
@@ -310,7 +310,9 @@ export let evalSuiviEleveCtl = ng.controller('EvalSuiviEleveCtl', [
                     });
                 }
                 await competenceNiveauFinal.saveNiveaufinal();
-                Utils.setMaxCompetenceShow(competence, $scope.suiviCompetence.tableConversions, isYear,false,$scope.listTeacher);
+                Utils.setMaxOrAverageCompetenceShow(competence, $scope.suiviCompetence.tableConversions, isYear,
+                    false, $scope.listTeacher);
+                utils.safeApply($scope);
             }
         };
 

--- a/src/main/resources/public/ts/models/common/Graph.ts
+++ b/src/main/resources/public/ts/models/common/Graph.ts
@@ -429,30 +429,22 @@ export class Graph extends Model{
                 let nbrCompNotes = (!matiereOrDomaine.competencesNotesEleve) ? 0 :
                     (matiereOrDomaine.competencesNotesEleve.length - nbrCompNotesUnevaluated);
 
-                let nbrCompNotes_set1 = _.union(
-                    _.where(matiereOrDomaine.competencesNotesEleve, {evaluation: 0, niveau_final: null}),
-                    _.where(matiereOrDomaine.competencesNotesEleve, {niveau_final: 0}));
+                let nbrCompNotes_set1 = _.where(matiereOrDomaine.competencesNotesEleve, {evaluationGraph: 0});
                 nbrCompNotes_set1 = !(nbrCompNotes_set1) ? 0 : nbrCompNotes_set1.length;
                 let set1_val = Math.min(diviseur, diviseur * (nbrCompNotes_set1 / (nbrCompNotes)));
                 let set1_percent = `${(nbrCompNotes_set1 * 100 / (nbrCompNotes)).toFixed(1)} %`;
 
-                let nbrCompNotes_set2 = _.union(
-                    _.where(matiereOrDomaine.competencesNotesEleve, {evaluation: 1, niveau_final: null}),
-                    _.where(matiereOrDomaine.competencesNotesEleve, {niveau_final: 1}));
+                let nbrCompNotes_set2 = _.where(matiereOrDomaine.competencesNotesEleve, {evaluationGraph: 1});
                 nbrCompNotes_set2 = !(nbrCompNotes_set2) ? 0 : nbrCompNotes_set2.length;
                 let set2_val = Math.min(diviseur, diviseur * (nbrCompNotes_set2 / (nbrCompNotes)) + set1_val);
                 let set2_percent = `${(nbrCompNotes_set2 * 100 / (nbrCompNotes)).toFixed(1)} %`;
 
-                let nbrCompNotes_set3 = _.union(
-                    _.where(matiereOrDomaine.competencesNotesEleve, {evaluation: 2, niveau_final: null}),
-                    _.where(matiereOrDomaine.competencesNotesEleve, {niveau_final: 2}));
+                let nbrCompNotes_set3 = _.where(matiereOrDomaine.competencesNotesEleve, {evaluationGraph: 2});
                 nbrCompNotes_set3 = !(nbrCompNotes_set3) ? 0 : nbrCompNotes_set3.length;
                 let set3_val = Math.min(diviseur, diviseur * (nbrCompNotes_set3 / (nbrCompNotes)) + set2_val);
                 let set3_percent = `${(nbrCompNotes_set3 * 100 / (nbrCompNotes)).toFixed(1)} %`;
 
-                let nbrCompNotes_set4 = _.union(
-                    _.where(matiereOrDomaine.competencesNotesEleve, {evaluation: 3, niveau_final: null}),
-                    _.where(matiereOrDomaine.competencesNotesEleve, {niveau_final: 3}));
+                let nbrCompNotes_set4 = _.where(matiereOrDomaine.competencesNotesEleve, {evaluationGraph: 3});
                 nbrCompNotes_set4 = !(nbrCompNotes_set4) ? 0 : nbrCompNotes_set4.length;
                 let set4_val = Math.min(diviseur, diviseur * (nbrCompNotes_set4 / (nbrCompNotes)) + set3_val);
                 let set4_percent = `${(nbrCompNotes_set4 * 100 / (nbrCompNotes)).toFixed(1)} %`;

--- a/src/main/resources/public/ts/models/teacher/Structure.ts
+++ b/src/main/resources/public/ts/models/teacher/Structure.ts
@@ -15,7 +15,7 @@
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-import {_, Collection, http, idiom as lang, model, Model, angular} from 'entcore';
+import {_, Collection, http, idiom as lang, model, Model, angular, toasts} from 'entcore';
 import * as utils from '../../utils/teacher';
 import {
     Annotation,
@@ -40,6 +40,7 @@ import {
 } from './index';
 import {Mix} from "entcore-toolkit";
 import httpAxios from 'axios';
+import {StructureOptions, structureOptionsService} from "../../services";
 
 function castClasses(classes: any) {
     return _.map(classes, (classe) => {
@@ -80,6 +81,7 @@ export class Structure extends Model {
     detailsUser: any;
     composer: any; // Set By infra
     services: any[];
+    options: StructureOptions;
 
     get api() {
         return {
@@ -150,6 +152,12 @@ export class Structure extends Model {
             .done(function (res) {
                 that.baremeDNBvisible = res[0].visible;
             }.bind(this));
+        structureOptionsService.getStructureOptionsIsAverageSkills(that.id).then(res =>{
+            that.options = res;
+        }).catch((err) => {
+            toasts.warning('competences.structure.options.error.get');
+            console.log(err);
+        });
 
         this.collection(NiveauCompetence, {
             sync: async function () {

--- a/src/main/resources/public/ts/models/teacher/SuiviCompetenceClasse.ts
+++ b/src/main/resources/public/ts/models/teacher/SuiviCompetenceClasse.ts
@@ -27,6 +27,7 @@ export class SuiviCompetenceClasse extends Model {
     periode : Periode;
     matieres: Collection<Matiere>;
     tableauConversion: any;
+    structure: Structure;
 
     get api() {
         return {
@@ -38,6 +39,7 @@ export class SuiviCompetenceClasse extends Model {
     constructor (classe : Classe, periode : any,structure : Structure) {
         super();
         this.periode = periode;
+        this.structure = structure;
         var that = this;
         this.collection(Matiere);
 
@@ -106,10 +108,10 @@ export class SuiviCompetenceClasse extends Model {
     }
 
     async getCompetencesNotesClasse (classe : Classe, periode : any): Promise<any> {
-        let urlComp = this.api.getCompetencesNotesClasse + classe.id + "/" + classe.type_groupe;
+        let urlComp = this.api.getCompetencesNotesClasse + classe.id + "/" + classe.type_groupe + "?structureId=" + this.structure.id;
         if (periode !== null && periode !== undefined && periode !== '*') {
             if(periode.id_type !== undefined && periode.id_type !== null){
-                urlComp += "?idPeriode="+periode.id_type;
+                urlComp += "&idPeriode="+periode.id_type;
             }
         }
         return http.get(`${urlComp}`);

--- a/src/main/resources/public/ts/parameter.ts
+++ b/src/main/resources/public/ts/parameter.ts
@@ -1,7 +1,6 @@
 import {ng} from "entcore";
 import {ParameterService} from "./services";
 import {adminParameterController} from "./controllers/admin-parameter"
-import * as services from './services';
 import {cFilAriane} from "./utils/directives/cFilAriane";
 import {navigable} from "./utils/directives/navigable";
 import {navigatable} from "./utils/directives/navigatable";
@@ -21,6 +20,7 @@ import {messageLoader} from "./utils/directives/messageLoading";
 import {inputTextList} from "./directives/inputTextList";
 import {teachingsSkills} from "./directives/teachingsSkills";
 import {cSkillsBubble} from "./directives/cSkillsBubble";
+
 ng.addRequiredModule('chart.js');
 ng.services.push(ParameterService);
 ng.controllers.push(adminParameterController);

--- a/src/main/resources/public/ts/services/index.ts
+++ b/src/main/resources/public/ts/services/index.ts
@@ -1,2 +1,3 @@
 export * from './ReportModelPrintExportService';
 export * from './parameter';
+export * from './structure-options.service';

--- a/src/main/resources/public/ts/services/structure-options.service.ts
+++ b/src/main/resources/public/ts/services/structure-options.service.ts
@@ -1,0 +1,35 @@
+import {ng} from 'entcore'
+import http, {AxiosResponse} from 'axios';
+
+export interface StructureOptions {
+    isSkillAverage ?: boolean;
+    structureId : string;
+}
+export interface IStructureOptionsService {
+
+    getStructureOptionsIsAverageSkills(structureId: String): Promise<StructureOptions>;
+
+    saveStrustureOptinsIsAverageSkills(options: StructureOptions): Promise<AxiosResponse>;
+}
+
+
+export const structureOptionsService: IStructureOptionsService = {
+
+
+    getStructureOptionsIsAverageSkills: async(structureId: string): Promise<StructureOptions> => {
+        try {
+            const response : AxiosResponse = await http.get(`competences/structure/${structureId}/options/isSkillAverage`);
+            return {structureId:  structureId, isSkillAverage: response.data.is_average_skills} ;
+        } catch (err) {
+            throw err;
+        }
+
+    },
+
+    saveStrustureOptinsIsAverageSkills: async(options: StructureOptions): Promise<AxiosResponse> =>{
+        return http.post(`competences/structure/options/isSkillAverage`, options);
+    }
+
+};
+
+export const StructureOptionsService = ng.service('structureOptionsService', (): IStructureOptionsService => structureOptionsService)

--- a/src/main/resources/public/ts/sniplets/structure-option-is-average-skills.ts
+++ b/src/main/resources/public/ts/sniplets/structure-option-is-average-skills.ts
@@ -1,0 +1,50 @@
+
+import {
+    structureOptionsService,
+    IStructureOptionsService,
+    StructureOptionsService,
+    StructureOptions
+} from "../services";
+
+import {toasts} from "entcore";
+import {safeApply} from "../utils/functions/safeApply";
+
+export class SnipletStructureOptions {
+   option : StructureOptions;
+
+    constructor( private $scope: any, private structureOptionsService: IStructureOptionsService) {
+        this.initOptionsIsAverageSkills($scope.source.idStructure);
+    }
+
+    async initOptionsIsAverageSkills(structureId: string): Promise<void> {
+        try {
+            this.option = await this.structureOptionsService.getStructureOptionsIsAverageSkills(structureId);
+            safeApply(this.$scope);
+        } catch (err) {
+            console.error(err);
+            toasts.warning('competences.structure.options.error.get')
+        }
+    }
+
+    async saveOptionIsAverageSkills () : Promise<void> {
+        try {
+            await this.structureOptionsService.saveStrustureOptinsIsAverageSkills(this.option);
+        } catch (err ) {
+            console.error(err);
+            this.option.isSkillAverage = !this.option.isSkillAverage;
+            safeApply(this.$scope);
+            toasts.warning('competences.structure.options.error.save')
+        }
+
+    }
+}
+export const structureOptionIsAverageSkills = {
+    title: 'choose calculate skill items',
+    description: 'choose the calculation of the average of the skill items',
+    controller: {
+        init: function(): void {
+            console.log('load snipplet isAveargeSkills');
+            this.vm = new SnipletStructureOptions(this, structureOptionsService);
+        }
+    }
+};

--- a/src/main/resources/sql/037-addColumnStructureOptions.sql
+++ b/src/main/resources/sql/037-addColumnStructureOptions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notes.structure_options ADD COLUMN is_average_skills boolean DEFAULT false;


### PR DESCRIPTION
## Describe your changes
onglet competence dans viescolaire, premier menu
ajout d'une snipplet pour choisir le clacul des items de compétences : moyenne -> true, max -> false (valeur par défaut)
L'application sera faite sur une une branche. Cette PR est liée à la PR [#49](https://github.com/OPEN-ENT-NG/vie-scolaire/pull/49) de viscolaire sur la branche MSV-73
[API Documentation](https://confluence.support-ent.fr/display/MN/%5BNotes%5D+structureOptions)
## Checklist tests
Dans viescolaire -> onglet Competences -> menu Niveau de maitrice et calcul du niveau la snipplet du choix du calcul du niveau des items de compétences
## Issue ticket number and link
[EVAL-334](https://jira.support-ent.fr/browse/EVAL-334)
[MVS-73](https://jira.support-ent.fr/browse/MVS-73)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

