### PR TITLE
feat(titleAssessments): #EVAL-175 adding title of the assessments for all users

### DIFF
--- a/src/main/resources/public/template/parent_enfant/releve/releve_notes.html
+++ b/src/main/resources/public/template/parent_enfant/releve/releve_notes.html
@@ -50,10 +50,10 @@
                                 </div>
                             </div>
                             <div class="gradetooltip"
-                                 ng-if="devoirReleveNotes.id_matiere === matiere.id && me.type === 'PERSRELELEVE'"
+                                 ng-if="devoirReleveNotes.id_matiere === matiere.id"
                                  tooltip="[[getFormatedDate(devoirReleveNotes.date)]]<p>[[devoirReleveNotes.name]]<div>[[devoirReleveNotes._sousmatiere_libelle]]</p>[[devoirReleveNotes.appreciation]]"></div>
                             <div class="gradetooltip"
-                                 ng-if="me.type === 'ELEVE' && devoirReleveNotes.id_matiere === matiere.id"
+                                 ng-if="devoirReleveNotes.id_matiere === matiere.id"
                                  tooltip="[[getFormatedDate(devoirReleveNotes.date)]]<br>[[devoirReleveNotes.name]]<div>[[devoirReleveNotes._sousmatiere_libelle]]</div>"></div>
                         </div>
                     </div>
@@ -115,11 +115,11 @@
                                 </div>
                             </div>
                             <div class="gradetooltip"
-                                 ng-if="me.type === 'PERSRELELEVE'"
+                                 ng-if="devoirReleveNotes.id_sousmatiere === sousMatiere.id_type_sousmatiere"
                                  tooltip="[[getFormatedDate(devoirReleveNotes.date)]]<p>[[devoirReleveNotes.name]]
 						            <div>[[devoirReleveNotes._sousmatiere_libelle]]</p>[[devoirReleveNotes.appreciation]]"></div>
                             <div class="gradetooltip"
-                                 ng-if="me.type === 'ELEVE'"
+                                 ng-if="devoirReleveNotes.id_sousmatiere === sousMatiere.id_type_sousmatiere"
                                  tooltip="[[getFormatedDate(devoirReleveNotes.date)]]<br>[[devoirReleveNotes.name]]
                                     <div>[[devoirReleveNotes._sousmatiere_libelle]]</div>"></div>
                         </div>


### PR DESCRIPTION
## Describe your changes
When hovering over the grades, the name of the assessment that gives that grade is displayed (as it is in the student view).

## Checklist tests
Connect with an account (not sudent) and in "Compétences" go to "Suivi Elève" --> "Suivi des notes" and move your cursor over the grades.

## Issue ticket number and link
[EVAL-175](https://jira.support-ent.fr/browse/EVAL-175)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

