### PR TITLE
fix(conseil de classe) : eval-380 wrong average for domains graphs

### DIFF
--- a/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
@@ -601,6 +601,8 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
             values.add(periodeId);
         }
 
+        query.append("AND devoirs.eval_lib_historise = false ");
+
         Sql.getInstance().prepared(query.toString(), values,Competences.DELIVERY_OPTIONS, validResultHandler(handler));
     }
 


### PR DESCRIPTION
## Describe your changes
Fixed old competences notes (historise) being used for Bilan par domaine averages computes in Conseil de classe for Trimester 3, leading in wrong results.

## Checklist tests
Coméptences -> Conseil de classe -> Chose a class+period+student -> Graphiques -> Bilan par domaine -> Check if positionning averages are the right ones.

## Issue ticket number and link
[EVAL-380](https://jira.support-ent.fr/browse/EVAL-380)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

