### PR TITLE
fix(sous-matiere) : eval-384 fixed services params displaying a 1 when the coefficient is of 0

### DIFF
--- a/src/main/resources/public/ts/models/sniplets/subtopicservice.service.ts
+++ b/src/main/resources/public/ts/models/sniplets/subtopicservice.service.ts
@@ -37,7 +37,9 @@ export class SubtopicserviceService implements Selectable{
         this.id_group = data.id_group;
         this.id_topic = data.id_topic;
         this.id_subtopic = data.id_subtopic;
-        this.coefficient = (parseFloat(data.coefficient)) ? parseFloat(data.coefficient) : 1;
+        this.coefficient = (parseFloat(data.coefficient));
+        if (this.coefficient == null)
+            this.coefficient = 1;
         return this;
     }
 }


### PR DESCRIPTION
## Describe your changes
Fixed services params displaying a 1 when the coefficient is of 0.

## Checklist tests
VieScolaire -> Compétences -> Modalités des services -> Put a service subtopic coeff to 0, reload the page and check if it's still at 0.

## Issue ticket number and link
[EVAL-384](https://jira.support-ent.fr/browse/EVAL-384)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

