### PR TITLE
fix(ExportPDF) : EVAL-391 Fixed student marks PDF having a 2 decimals average

### DIFF
--- a/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
+++ b/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
@@ -1109,7 +1109,7 @@ public class ExportPDFController extends ControllerHelper {
                                         note.put("nonEvalue", false);
 
                                         DecimalFormat decimalFormat = new DecimalFormat("#.0");
-                                        decimalFormat.setRoundingMode(RoundingMode.HALF_UP);//with this mode 2.125 -> 2.13 without 2.125 -> 2.12
+                                        decimalFormat.setRoundingMode(RoundingMode.HALF_UP);
 
                                         String moyCalcule = decimalFormat.format(resultNote.getDouble(MOYENNE).doubleValue());
                                         if (isHabilite)

--- a/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
+++ b/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
@@ -1108,7 +1108,7 @@ public class ExportPDFController extends ControllerHelper {
                                         note.put("persoColor", niveau.getString("persoColor"));
                                         note.put("nonEvalue", false);
 
-                                        DecimalFormat decimalFormat = new DecimalFormat("#0.0");
+                                        DecimalFormat decimalFormat = new DecimalFormat("#.0");
                                         decimalFormat.setRoundingMode(RoundingMode.HALF_UP);//with this mode 2.125 -> 2.13 without 2.125 -> 2.12
 
                                         String moyCalcule = decimalFormat.format(resultNote.getDouble(MOYENNE).doubleValue());


### PR DESCRIPTION
## Describe your changes
EVAL-391 Fixed student marks PDF having a 2 decimals average instead of 1 decimal average like everything else.

## Checklist tests
Competences -> Suivi Eleve -> Suivi des notes -> Faire un export et vérifier que les moyennes de matières aient bien une seule décimale.

## Issue ticket number and link
[EVAL-391](https://jira.support-ent.fr/browse/EVAL-391)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

