### PR TITLE
fix(CreationCompetence) : EVAL-390 Fixed competence not being created in empty connaissance.

### DIFF
--- a/src/main/resources/public/ts/sniplets/itemsCompetences.ts
+++ b/src/main/resources/public/ts/sniplets/itemsCompetences.ts
@@ -226,7 +226,7 @@ export const itemsCompetences = {
                 id_cycle: connaissance.id_cycle,
                 id_enseignement: connaissance.id_enseignement,
                 id_type: 2,
-                ids_domaine: connaissance.ids_domaine_int,
+                ids_domaine: (connaissance.ids_domaine_int != null ? connaissance.ids_domaine_int : []),
                 id_etablissement: this.itemsCompetences.that.structure.id
             };
             this.itemsCompetences.that.printDomaines = _.clone(domaines);


### PR DESCRIPTION
## Describe your changes

Fixed competence not being created in empty connaissance in VieScolaire Competence snipplet if no competences were previously there in a connaissance.

## Checklist tests

VieScolaire -> Competences -> Items de competence -> Try to create a competence on an empty connaissance, it should work.

## Issue ticket number and link

[EVAL-390](https://jira.support-ent.fr/browse/EVAL-390)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

