### PR TITLE
fix(parents) : EVAL-411 Fixed infinite load as a 2 children parent.

### DIFF
--- a/src/main/resources/public/ts/controllers/eval_parent_ctl.ts
+++ b/src/main/resources/public/ts/controllers/eval_parent_ctl.ts
@@ -307,8 +307,10 @@ export let evaluationsController = ng.controller('EvaluationsController', [
                             foundedPeriode = true;
                         } else if (($scope.search.periode) && !foundedPeriode){
                             $scope.periode = periodes.findWhere({id_type: $scope.search.periode.id_type});
-                            foundedPeriode = true;
-                        } else if(!foundedPeriode){
+                            if ($scope.periode != null)
+                                foundedPeriode = true;
+                        }
+                        if(!foundedPeriode){
                             if (momentCurrPeriodeDebut.diff(momentCurrDate) <= 0
                                 && momentCurrDate.diff(momentCurrPeriodeFin) <= 0) {
                                 $scope.periode = periodes.findWhere({id: periodes.all[i].id});


### PR DESCRIPTION
## Describe your changes
Fixed getting an infinite load as a parent with 2 children in different periods category (such as one in semester class and one in trimester class) when switching which child to view.

## Checklist tests
Get a parent with 2 children, one with a class in semester, the other in trimester. Login and try to switch which children to view. It should now work.

## Issue ticket number and link
[EVAL-411](https://jira.support-ent.fr/browse/EVAL-411)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

