### PR TITLE
fix(bulletins) : EVAL-407 Fixed bulletins columns being shifted when not having subtopics.

### DIFF
--- a/src/main/resources/public/template/pdf/bulletin.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/bulletin.pdf.xhtml
@@ -653,6 +653,13 @@
             {{/hasSousMatiere}}
             {{/printSousMatieres}}
             {{^printSousMatieres}}
+            {{#printCoefficient}}
+            <td rowspan="{{rowSpan}}"
+                style="text-align: center; background-color: {{{backgroundColor}}};word-wrap:break-word; {{{style}}}"
+                class="onePadding">
+                {{coef}}
+            </td>
+            {{/printCoefficient}}
             {{#getMoyenneEleve}}
             <td style="font-size: x-small; font-weight: bold; background-color: {{{backgroundColor}}} "
                 class="onePadding">


### PR DESCRIPTION
## Describe your changes
Fixed bulletins columns being shifted when not having subtopics.

## Checklist tests
Generate a bulletin without subtopics and check if the columns are right.

## Issue ticket number and link
[EVAL-407](https://jira.support-ent.fr/browse/EVAL-407)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

