### PR TITLE
fix(security): #EVAL-444 improve api's route security on ModaliteController

### DIFF
--- a/src/main/java/fr/openent/competences/Competences.java
+++ b/src/main/java/fr/openent/competences/Competences.java
@@ -184,7 +184,7 @@ public class Competences extends BaseServer {
     // droits
     public static final String DEVOIR_ACTION_UPDATE = "fr-openent-competences-controllers-DevoirController|updateDevoir";
     public static final String PARAM_COMPETENCE_RIGHT = "competences.paramCompetences";
-    public static final String PARAM_SERVICES_RIGHT = "viesco.paramServices";
+    public static final String PARAM_SERVICES_RIGHT = "viescolaire.paramServices";
     public static final String PARAM_LINK_GROUP_CYCLE_RIGHT = "competences.paramLinkGroupCycle";
     public static final String CAN_UPDATE_RETARDS_AND_ABSENCES = "competences.canUpdateRetardsAndAbsences";
     public static final String CAN_ACCESS_EXPORT_BULLETIN = "export.bulletins.periodique";

--- a/src/main/java/fr/openent/competences/controllers/ModaliteController.java
+++ b/src/main/java/fr/openent/competences/controllers/ModaliteController.java
@@ -18,6 +18,7 @@
 package fr.openent.competences.controllers;
 
 import fr.openent.competences.Competences;
+import fr.openent.competences.security.AccessViscoParamServiceStructure;
 import fr.openent.competences.service.ModaliteService;
 import fr.openent.competences.service.impl.DefaultModaliteService;
 import fr.wseduc.rs.ApiDoc;
@@ -26,6 +27,7 @@ import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import io.vertx.core.http.HttpServerRequest;
 import org.entcore.common.controller.ControllerHelper;
+import org.entcore.common.http.filter.ResourceFilter;
 
 import static org.entcore.common.http.response.DefaultResponseHandler.arrayResponseHandler;
 
@@ -37,9 +39,14 @@ public class ModaliteController extends ControllerHelper {
         this.modaliteService = new DefaultModaliteService(Competences.COMPETENCES_SCHEMA, Competences.MODALITES_TABLE);
     }
 
+    /**
+     * @param request
+     * @queryParam {idEtablissement} mandatory
+     */
     @Get("/modalites")
     @ApiDoc("Récupère les modalités")
-    @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(AccessViscoParamServiceStructure.class)
     public void getDefaultServices(final HttpServerRequest request) {
         this.modaliteService.getModalites(arrayResponseHandler(request));
     }

--- a/src/main/java/fr/openent/competences/security/AccessIfMyStructure.java
+++ b/src/main/java/fr/openent/competences/security/AccessIfMyStructure.java
@@ -15,5 +15,6 @@ public class AccessIfMyStructure implements ResourcesProvider {
 
             String structureId = WorkflowActionUtils.getParamStructure(httpServerRequest);
             handler.handle(structureId != null && userInfos.getStructures().contains(structureId));
+
     }
 }

--- a/src/main/java/fr/openent/competences/security/AccessViscoParamServiceStructure.java
+++ b/src/main/java/fr/openent/competences/security/AccessViscoParamServiceStructure.java
@@ -1,0 +1,19 @@
+package fr.openent.competences.security;
+
+import fr.openent.competences.Competences;
+import fr.openent.competences.security.utils.WorkflowActionUtils;
+import fr.openent.competences.security.utils.WorkflowActions;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
+
+public class AccessViscoParamServiceStructure implements ResourcesProvider {
+    @Override
+    public void authorize(HttpServerRequest request, Binding binding, UserInfos userInfos, Handler<Boolean> handler) {
+        String structureId = WorkflowActionUtils.getParamStructure(request);
+        handler.handle(structureId != null && userInfos.getStructures().contains(structureId)
+                && WorkflowActionUtils.hasRight(userInfos, WorkflowActions.PARAM_SERVICES_RIGHT.toString()));
+    }
+}

--- a/src/main/java/fr/openent/competences/security/utils/WorkflowActions.java
+++ b/src/main/java/fr/openent/competences/security/utils/WorkflowActions.java
@@ -41,7 +41,8 @@ public enum WorkflowActions {
 	CREATE_AVIS_CONSEIL_BILAN_PERIODIQUE("create.avis.conseil.bilan.periodique"),
 	CAN_UPDATE_NIVEAU_ENS_CPL("can.update.niveau.ens.cpl"),
 	ACCESS_EXPORT_BULLETIN("export.bulletins.periodique"),
-	ACCESS_SUIVI_CLASSE("access.suivi.classe");
+	ACCESS_SUIVI_CLASSE("access.suivi.classe"),
+	PARAM_SERVICES_RIGHT("viescolaire.paramServices");
 
 	private final String actionName;
 

--- a/src/main/resources/public/ts/sniplets/paramServices.ts
+++ b/src/main/resources/public/ts/sniplets/paramServices.ts
@@ -513,7 +513,7 @@ export const paramServices = {
 
         getModalite: function() {
             try {
-                return http.get("/competences/modalites")
+                return http.get(`/competences/modalites?idEtablissement=${paramServices.that.idStructure}`)
             } catch (e) {
                 toasts.warning('evaluations.service.error.classe');
             }

--- a/src/test/java/fr/openent/competences/security/AccessViscoParamServiceStructureTest.java
+++ b/src/test/java/fr/openent/competences/security/AccessViscoParamServiceStructureTest.java
@@ -1,0 +1,131 @@
+package fr.openent.competences.security;
+
+import fr.openent.competences.Competences;
+import fr.openent.competences.security.utils.WorkflowActions;
+import fr.wseduc.webutils.http.Binding;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.HeadersAdaptor;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.user.UserInfos;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(VertxUnitRunner.class)
+public class AccessViscoParamServiceStructureTest {
+    AccessViscoParamServiceStructure access;
+    HttpServerRequest request;
+    Binding binding;
+    MultiMap map;
+    List<String> structures;
+    List<String> groupsIds;
+    UserInfos user = new UserInfos();
+    List<UserInfos.Action> actions;
+    UserInfos.Action role1;
+
+    @Before
+    public void setUp() throws NoSuchFieldException {
+        access = new AccessViscoParamServiceStructure();
+        request = Mockito.mock(HttpServerRequest.class);
+        binding = Mockito.mock(Binding.class);
+        map = Mockito.spy(new HeadersAdaptor(new DefaultHttpHeaders()));
+        structures = new ArrayList<>();
+        groupsIds = new ArrayList<>();
+        user = new UserInfos();
+        actions = new ArrayList<>();
+        role1 = new UserInfos.Action();
+    }
+
+    @Test
+    public void testAuthorize(TestContext ctx){
+        role1.setDisplayName(Competences.PARAM_SERVICES_RIGHT);
+        actions.add(role1);
+        user.setAuthorizedActions(actions);
+        map.set("structureId", "9af51dc6-ead0-4edb-8978-da14a3e9f49a");
+        Mockito.doReturn(map).when(request).params();
+        structures.add("9af51dc6-ead0-4edb-8978-da14a3e9f49a");
+        user.setStructures(structures);
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(true, result);
+            async.complete();
+        });
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testNullStructure(TestContext ctx){
+        role1.setDisplayName(WorkflowActions.PARAM_SERVICES_RIGHT.toString());
+        actions.add(role1);
+        user.setAuthorizedActions(actions);
+        //map.set("structureId", "9af51dc6-ead0-4edb-8978-da14a3e9f49a");
+        Mockito.doReturn(map).when(request).params();
+        structures.add("9af51dc6-ead0-4edb-8978-da14a3e9f49a");
+        user.setStructures(structures);
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(false, result);
+            async.complete();
+        });
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testBadStructure(TestContext ctx){
+        role1.setDisplayName(WorkflowActions.PARAM_SERVICES_RIGHT.toString());
+        actions.add(role1);
+        user.setAuthorizedActions(actions);
+        map.set("structureId", "9af51dc6-ead0-4edb-8978-da14a3e9f49a");
+        Mockito.doReturn(map).when(request).params();
+        structures.add("a1aaaa1aa1aa");
+        user.setStructures(structures);
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(false, result);
+            async.complete();
+        });
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testBadRight(TestContext ctx){
+        role1.setDisplayName(WorkflowActions.ACCESS_EXPORT_BULLETIN.toString());
+        actions.add(role1);
+        user.setAuthorizedActions(actions);
+        map.set("structureId", "9af51dc6-ead0-4edb-8978-da14a3e9f49a");
+        Mockito.doReturn(map).when(request).params();
+        structures.add("9af51dc6-ead0-4edb-8978-da14a3e9f49a");
+        user.setStructures(structures);
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(false, result);
+            async.complete();
+        });
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testBadRightAndBadStructure(TestContext ctx){
+        role1.setDisplayName(WorkflowActions.ACCESS_EXPORT_BULLETIN.toString());
+        actions.add(role1);
+        user.setAuthorizedActions(actions);
+        map.set("structureId", "9af51dc6-ead0-4edb-8978-da14a3e9f49a");
+        Mockito.doReturn(map).when(request).params();
+        structures.add("aaaa123a");
+        user.setStructures(structures);
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(false, result);
+            async.complete();
+        });
+        async.awaitSuccess(10000);
+    }
+}


### PR DESCRIPTION
## Describe your changes
- For the route @Get("/modalites") : add query param idEtablissement to check structure within the resourceFilter AccessViscoParamServiceStructure.class.
This filter checks whether the user has the right structure and whether he has the workflow right : viescolaire.paramServices .
## Checklist tests
- Unit tests AccessViscoParamServiceStructureTest
- Tests with front file paramServices via browser to check whether the structure id is passed with query param.
- To check the route, go to viescolaire, competences thumbnail and then, just click on "modalités de services" in the left menu.
## Issue ticket number and link
[#EVAL-444](https://jira.support-ent.fr/browse/EVAL-444)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

