### PR TITLE
feat(ExportClasse) : #EVAL-228 Adds the possibility to print skills results to Releve de notes in Suivi Class.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,5 @@ toolsVersion=2.0.0-final
 junitVersion=5.1.0
 powerMockVersion=2.0.2
 mockitoVersion=2.+
-entCoreVersion=4.8-SNAPSHOT
+entCoreVersion=4.9-SNAPSHOT
 opencsvVersion=3.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,5 @@ toolsVersion=2.0.0-final
 junitVersion=5.1.0
 powerMockVersion=2.0.2
 mockitoVersion=2.+
-entCoreVersion=4.9-SNAPSHOT
+entCoreVersion=4.8-SNAPSHOT
 opencsvVersion=3.9

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -15,9 +15,6 @@ public class Field {
     public static final String DOMAINHEADER = "domainHeader";
     public static final String DOMAINBODY = "domainBody";
     public static final String HASCOMPETENCESNOTES = "hasCompetencesNotes";
-    public static final String ID_COMPETENCE = "id_competence";
-    public static final String COMPETENCES = "competences";
-    public static final String CLASSES = "classes";
 
     private Field() {
         throw new IllegalStateException("Utility class");
@@ -31,7 +28,6 @@ public class Field {
     public static final String IDSTRUCTURE = "idStructure";
     public static final String STRUCTUREID = "structureId";
     public static final String IDETABLISSEMENT = "idEtablissement";
-    public static final String ID_ETABLISSEMENT = "id_etablissement";
     public static final String IDCLASSE = "idClasse";
     public static final String ID_STRUCTURE = "id_structure";
     public static final String ID_MATIERE = "id_matiere";

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -61,6 +61,9 @@ public class Field {
     public static final String GROUPID = "groupId";
     public static final String USERID = "userId";
     public static final String IDTYPEPERIODE = "idTypePeriode";
+    public static final String ID_COMPETENCE = "id_competence";
+    public static final String ID_CYCLE = "id_cycle";
+    public static final String ID_ETABLISSEMENT = "id_etablissement";
 
 
     public static final String MAIN_TEACHER_ID = "main_teacher_id";
@@ -158,6 +161,16 @@ public class Field {
     public static final String NAMECLASS = "nameClass";
     public static final String ELEMENTPROGRAMME = "elementProgramme";
     public static final String TABLECONVERSIONS = "tableConversions";
+    public static final String SKILLS = "skills";
+    public static final String SCORES = "scores";
+    public static final String EMPTY = "empty";
+    public static final String NIVEAU_FINAL = "niveau_final";
+    public static final String BODY = "body";
+    public static final String HEADER = "header";
+    public static final String COMPETENCESNOTES = "competencesNotes";
+    public static final String COMPETENCENOTES = "competenceNotes";
+    public static final String COMPETENCES = "competences";
+    public static final String CLASSES = "classes";
     //
 
     public static final String ISSKILLAVERAGE = "isSkillAverage";

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -15,7 +15,6 @@ public class Field {
     public static final String DOMAINHEADER = "domainHeader";
     public static final String DOMAINBODY = "domainBody";
     public static final String HASCOMPETENCESNOTES = "hasCompetencesNotes";
-    public static final String POSITIONNEMENTS_AUTO = "positionnements_auto";
 
     private Field() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -15,6 +15,7 @@ public class Field {
     public static final String DOMAINHEADER = "domainHeader";
     public static final String DOMAINBODY = "domainBody";
     public static final String HASCOMPETENCESNOTES = "hasCompetencesNotes";
+    public static final String POSITIONNEMENTS_AUTO = "positionnements_auto";
 
     private Field() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -175,6 +175,8 @@ public class Field {
     public static final String TABLECONVERSIONS = "tableConversions";
     public static final String SKILLS = "skills";
     public static final String SCORES = "scores";
+    public static final String SHOWSKILLS = "showSkills";
+    public static final String SHOWSCORES = "showScores";
     public static final String EMPTY = "empty";
     public static final String NIVEAU_FINAL = "niveau_final";
     public static final String BODY = "body";

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -3,6 +3,18 @@ package fr.openent.competences.constants;
 public class Field {
 
 
+    public static final String DEFAULT_LIB = "default_lib";
+    public static final String VISU = "visu";
+    public static final String LETTRE = "lettre";
+    public static final String DEFAULT = "default";
+    public static final String PERSOCOLOR = "persoColor";
+    public static final String COULEUR = "couleur";
+    public static final String RIGHT = "right";
+    public static final String NOM = "nom";
+    public static final String LEFT = "left";
+    public static final String DOMAINHEADER = "domainHeader";
+    public static final String DOMAINBODY = "domainBody";
+    public static final String HASCOMPETENCESNOTES = "hasCompetencesNotes";
     public static final String ID_COMPETENCE = "id_competence";
     public static final String COMPETENCES = "competences";
     public static final String CLASSES = "classes";

--- a/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
+++ b/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
@@ -160,17 +160,17 @@ public class ExportPDFController extends ControllerHelper {
             final Long idTypePeriode = params.getLong("idTypePeriode");
             final Long ordre = params.getLong(ORDRE);
             final String classeName = params.getString(CLASSE_NAME_KEY);
-            final boolean skills = request.params().contains(Field.SKILLS) && Boolean.parseBoolean(request.params().get(Field.SKILLS));
-            final boolean scores = request.params().contains(Field.SCORES) && Boolean.parseBoolean(request.params().get(Field.SCORES));
-            exportService.getDataForExportReleveClasse(idClasse, idEtablissement, idPeriode, idTypePeriode, ordre, scores,
-                    skills, event -> {
+            final boolean showSkills = request.params().contains(Field.SKILLS) && Boolean.parseBoolean(request.params().get(Field.SKILLS));
+            final boolean showScores = request.params().contains(Field.SCORES) && Boolean.parseBoolean(request.params().get(Field.SCORES));
+            exportService.getDataForExportReleveClasse(idClasse, idEtablissement, idPeriode, idTypePeriode, ordre, showScores,
+                    showSkills, event -> {
                 if(event.isLeft()){
                     leftToResponse(request, event.left());
                     return;
                 }
                 JsonObject templateProps = event.right().getValue()
-                        .put(Field.SHOWSKILLS, skills)
-                        .put(Field.SHOWSCORES, scores);
+                        .put(Field.SHOWSKILLS, showSkills)
+                        .put(Field.SHOWSCORES, showScores);
                 String templateName = "releve-classe.pdf.xhtml";
                 String prefixPdfName = "releve-classe_" +  classeName;
                 exportService.genererPdf(request, templateProps, templateName, prefixPdfName, vertx, config);

--- a/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
+++ b/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
@@ -160,15 +160,17 @@ public class ExportPDFController extends ControllerHelper {
             final Long idTypePeriode = params.getLong("idTypePeriode");
             final Long ordre = params.getLong(ORDRE);
             final String classeName = params.getString(CLASSE_NAME_KEY);
-            final Boolean skills = request.params().contains(Field.SKILLS) && Boolean.parseBoolean(request.params().get(Field.SKILLS));
-            final Boolean scores = request.params().contains(Field.SCORES) && Boolean.parseBoolean(request.params().get(Field.SCORES));
+            final boolean skills = request.params().contains(Field.SKILLS) && Boolean.parseBoolean(request.params().get(Field.SKILLS));
+            final boolean scores = request.params().contains(Field.SCORES) && Boolean.parseBoolean(request.params().get(Field.SCORES));
             exportService.getDataForExportReleveClasse(idClasse, idEtablissement, idPeriode, idTypePeriode, ordre, scores,
                     skills, event -> {
                 if(event.isLeft()){
                     leftToResponse(request, event.left());
                     return;
                 }
-                JsonObject templateProps = event.right().getValue();
+                JsonObject templateProps = event.right().getValue()
+                        .put(Field.SHOWSKILLS, skills)
+                        .put(Field.SHOWSCORES, scores);
                 String templateName = "releve-classe.pdf.xhtml";
                 String prefixPdfName = "releve-classe_" +  classeName;
                 exportService.genererPdf(request, templateProps, templateName, prefixPdfName, vertx, config);

--- a/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
+++ b/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
@@ -160,7 +160,10 @@ public class ExportPDFController extends ControllerHelper {
             final Long idTypePeriode = params.getLong("idTypePeriode");
             final Long ordre = params.getLong(ORDRE);
             final String classeName = params.getString(CLASSE_NAME_KEY);
-            exportService.getDataForExportReleveClasse(idClasse, idEtablissement, idPeriode, idTypePeriode, ordre, event -> {
+            final Boolean skills = request.params().contains(Field.SKILLS) && Boolean.parseBoolean(request.params().get(Field.SKILLS));
+            final Boolean scores = request.params().contains(Field.SCORES) && Boolean.parseBoolean(request.params().get(Field.SCORES));
+            exportService.getDataForExportReleveClasse(idClasse, idEtablissement, idPeriode, idTypePeriode, ordre, scores,
+                    skills, event -> {
                 if(event.isLeft()){
                     leftToResponse(request, event.left());
                     return;

--- a/src/main/java/fr/openent/competences/service/DevoirService.java
+++ b/src/main/java/fr/openent/competences/service/DevoirService.java
@@ -18,6 +18,7 @@
 package fr.openent.competences.service;
 
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.EventBus;
@@ -120,6 +121,9 @@ public interface DevoirService extends CrudService {
     void listDevoirs(String idEleve, String[] idGroupes, Long[] idDevoirs, Long[] idPeriodes,
                      String[] idEtablissement, String[] idMatieres, Boolean hasCompetences,
                      Boolean historise, Handler<Either<String, JsonArray>> handler);
+
+    Future<JsonArray> listDevoirs(String idEleve, String[] idGroupes, Long[] idDevoirs, Long[] idPeriodes,
+                                  String[] idEtablissements, String[] idMatieres, Boolean hasCompetences, Boolean historise);
 
     void listDevoirsWithAnnotations(String idEleve, Long idPeriode, String idMatiere,
                                     Handler<Either<String, JsonArray>> handler);

--- a/src/main/java/fr/openent/competences/service/DevoirService.java
+++ b/src/main/java/fr/openent/competences/service/DevoirService.java
@@ -122,8 +122,8 @@ public interface DevoirService extends CrudService {
                      String[] idEtablissement, String[] idMatieres, Boolean hasCompetences,
                      Boolean historise, Handler<Either<String, JsonArray>> handler);
 
-    Future<JsonArray> listDevoirs(String idEleve, String[] idGroupes, Long[] idDevoirs, Long[] idPeriodes,
-                                  String[] idEtablissements, String[] idMatieres, Boolean hasCompetences, Boolean historise);
+    Future<JsonArray> listDevoirs(String studentId, String[] groupIds, Long[] homeworkIds, Long[] periodIds,
+                                  String[] structureIds, String[] subjectIds, Boolean hasSkills, Boolean historized);
 
     void listDevoirsWithAnnotations(String idEleve, Long idPeriode, String idMatiere,
                                     Handler<Either<String, JsonArray>> handler);

--- a/src/main/java/fr/openent/competences/service/ExportService.java
+++ b/src/main/java/fr/openent/competences/service/ExportService.java
@@ -77,5 +77,5 @@ public interface ExportService {
                                      final MultiMap params, Handler<Either<String, JsonObject>> handler);
 
     void getDataForExportReleveClasse(String idClasse, String idEtablissement, Long idPeriode, final Long idTypePeriode,
-                                      final Long ordre, Boolean scores, Boolean skills, Handler<Either<String, JsonObject>> handler);
+                                      final Long ordre, Boolean showScores, Boolean showSkills, Handler<Either<String, JsonObject>> handler);
 }

--- a/src/main/java/fr/openent/competences/service/ExportService.java
+++ b/src/main/java/fr/openent/competences/service/ExportService.java
@@ -77,5 +77,5 @@ public interface ExportService {
                                      final MultiMap params, Handler<Either<String, JsonObject>> handler);
 
     void getDataForExportReleveClasse(String idClasse, String idEtablissement, Long idPeriode, final Long idTypePeriode,
-                                      final Long ordre, Handler<Either<String, JsonObject>> handler);
+                                      final Long ordre, Boolean scores, Boolean skills, Handler<Either<String, JsonObject>> handler);
 }

--- a/src/main/java/fr/openent/competences/service/NoteService.java
+++ b/src/main/java/fr/openent/competences/service/NoteService.java
@@ -429,7 +429,17 @@ public interface NoteService extends CrudService {
      */
     Future<Void> insertOrUpdateAnnotation(String idDevoir, String idEleve, String annotation);
 
-
+    /**
+     * Récupère les compétences notes d'élèves selon divers critères
+     * @param ids ids d'élèves
+     * @param etablissementId etablissementId
+     * @param matiereId matiereId
+     * @param matiereIds matiereIds
+     * @param periodeId periodeId
+     * @param eleveId eleveId
+     * @param withDomaineInfo récupère ou non les infos de domaine
+     * @param isYear récupère ou non les infos à l'année
+     */
     void getCompetencesNotesReleveEleves(JsonArray ids, String etablissementId, String matiereId,
                                                 JsonArray matiereIds,
                                                 Long periodeId,  String eleveId, Boolean withDomaineInfo,

--- a/src/main/java/fr/openent/competences/service/NoteService.java
+++ b/src/main/java/fr/openent/competences/service/NoteService.java
@@ -19,10 +19,8 @@ package fr.openent.competences.service;
 
 import fr.openent.competences.bean.NoteDevoir;
 import fr.openent.competences.model.Service;
-import fr.openent.competences.service.impl.DefaultUtilsService;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerRequest;
 import org.entcore.common.service.CrudService;
@@ -431,17 +429,17 @@ public interface NoteService extends CrudService {
 
     /**
      * Récupère les compétences notes d'élèves selon divers critères
-     * @param ids ids d'élèves
-     * @param etablissementId etablissementId
-     * @param matiereId matiereId
-     * @param matiereIds matiereIds
-     * @param periodeId periodeId
-     * @param eleveId eleveId
-     * @param withDomaineInfo récupère ou non les infos de domaine
+     * @param studentIds ids d'élèves
+     * @param structureIds etablissementId
+     * @param subjectId matiereId
+     * @param subjectIds matiereIds
+     * @param periodId periodeId
+     * @param studentId eleveId
+     * @param withDomainInfo récupère ou non les infos de domaine
      * @param isYear récupère ou non les infos à l'année
      */
-    void getCompetencesNotesReleveEleves(JsonArray ids, String etablissementId, String matiereId,
-                                                JsonArray matiereIds,
-                                                Long periodeId,  String eleveId, Boolean withDomaineInfo,
+    void getCompetencesNotesReleveEleves(JsonArray studentIds, String structureIds, String subjectId,
+                                                JsonArray subjectIds,
+                                                Long periodId,  String studentId, Boolean withDomainInfo,
                                                 Boolean isYear, Handler<Either<String, JsonArray>> handler);
 }

--- a/src/main/java/fr/openent/competences/service/NoteService.java
+++ b/src/main/java/fr/openent/competences/service/NoteService.java
@@ -428,4 +428,10 @@ public interface NoteService extends CrudService {
      * @Return {@link Future} of result {@link Void}
      */
     Future<Void> insertOrUpdateAnnotation(String idDevoir, String idEleve, String annotation);
+
+
+    void getCompetencesNotesReleveEleves(JsonArray ids, String etablissementId, String matiereId,
+                                                JsonArray matiereIds,
+                                                Long periodeId,  String eleveId, Boolean withDomaineInfo,
+                                                Boolean isYear, Handler<Either<String, JsonArray>> handler);
 }

--- a/src/main/java/fr/openent/competences/service/UtilsService.java
+++ b/src/main/java/fr/openent/competences/service/UtilsService.java
@@ -156,6 +156,12 @@ public interface UtilsService {
     void getCycle(String idClasse, Handler<Either<String, JsonObject>> handler);
 
     /**
+     * Récupère le cycle de la classe dans la relation classe_cycle
+     * @param idClasse Identifiant de la classe.
+     */
+    Future<JsonObject> getCycle(String idClasse);
+
+    /**
      * Récupère la liste des utilisateurs selon les paramètres précisés
      *
      *

--- a/src/main/java/fr/openent/competences/service/impl/DefaultCompetencesService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultCompetencesService.java
@@ -213,7 +213,7 @@ public class DefaultCompetencesService extends SqlCrudService implements Compete
         String query = "SELECT string_agg(domaines.codification, ', ') as code_domaine," +
                 " string_agg( cast (domaines.id as text), ',') as ids_domaine, comp.id as id_competence," +
                 " compDevoir.*, COALESCE(compPerso.nom, comp.nom) AS nom, comp.id_type as id_type," +
-                " comp.id_parent as id_parent, compDevoir.index as index" +
+                " comp.id_parent as id_parent, compDevoir.index as index, devoir.id_matiere as id_matiere" +
                 " FROM " + COMPETENCES_TABLE + " AS comp" +
                 " INNER JOIN " + COMPETENCES_DEVOIRS_TABLE + " AS compDevoir ON (comp.id = compDevoir.id_competence )" +
                 " LEFT JOIN " + COMPETENCES_DOMAINES_TABLE + " AS compDom ON (comp.id = compDom.id_competence)" +
@@ -221,13 +221,14 @@ public class DefaultCompetencesService extends SqlCrudService implements Compete
                 " LEFT JOIN (SELECT nom, id_competence FROM " + COMPETENCES_PERSO_TABLE + " WHERE id_etablissement = ?"+
                 " ) AS compPerso" +
                 " ON comp.id = compPerso.id_competence" +
+                " LEFT JOIN " + DEVOIRS_TABLE + " AS devoir ON (compDevoir.id_devoir = devoir.id)" +
                 " WHERE compDevoir.id_devoir IN " + Sql.listPrepared(devoirIds.getList());
         JsonArray values = new JsonArray().add(idEtablissement).addAll(devoirIds);
         if (idCycle != null) {
             query += " AND comp.id_cycle = ?";
             values.add(idCycle);
         }
-        query += " GROUP BY compDevoir.id, COALESCE(compPerso.nom, comp.nom), comp.id_type, comp.id_parent, comp.id" +
+        query += " GROUP BY compDevoir.id, COALESCE(compPerso.nom, comp.nom), comp.id_type, comp.id_parent, comp.id, devoir.id_matiere" +
                  " ORDER BY (compDevoir.index ,compDevoir.id);";
 
         Sql.getInstance().prepared(query, values,

--- a/src/main/java/fr/openent/competences/service/impl/DefaultCompetencesService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultCompetencesService.java
@@ -209,6 +209,10 @@ public class DefaultCompetencesService extends SqlCrudService implements Compete
     }
     public void getDevoirCompetences(JsonArray devoirIds, String idEtablissement, Long idCycle,
                                      final Handler<Either<String, JsonArray>> handler) {
+        if (null == devoirIds || devoirIds.isEmpty()){
+            handler.handle(new Either.Right<>(new JsonArray()));
+            return;
+        }
 
         String query = "SELECT string_agg(domaines.codification, ', ') as code_domaine," +
                 " string_agg( cast (domaines.id as text), ',') as ids_domaine, comp.id as id_competence," +

--- a/src/main/java/fr/openent/competences/service/impl/DefaultDevoirService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultDevoirService.java
@@ -921,10 +921,10 @@ public class DefaultDevoirService extends SqlCrudService implements fr.openent.c
     }
 
     @Override
-    public Future<JsonArray> listDevoirs(String idEleve, String[] idGroupes, Long[] idDevoirs, Long[] idPeriodes,
-                String[] idEtablissements, String[] idMatieres, Boolean hasCompetences, Boolean historise) {
+    public Future<JsonArray> listDevoirs(String studentId, String[] groupIds, Long[] homeworkIds, Long[] periodIds,
+        String[] structureIds, String[] subjectIds, Boolean hasSkills, Boolean historized) {
         Promise<JsonArray> promise = Promise.promise();
-        listDevoirs(idEleve, idGroupes, idDevoirs, idPeriodes, idEtablissements, idMatieres, hasCompetences, historise,
+        listDevoirs(studentId, groupIds, homeworkIds, periodIds, structureIds, subjectIds, hasSkills, historized,
                 FutureHelper.handlerJsonArray(promise.future()));
         return promise.future();
     }

--- a/src/main/java/fr/openent/competences/service/impl/DefaultDevoirService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultDevoirService.java
@@ -921,6 +921,15 @@ public class DefaultDevoirService extends SqlCrudService implements fr.openent.c
     }
 
     @Override
+    public Future<JsonArray> listDevoirs(String idEleve, String[] idGroupes, Long[] idDevoirs, Long[] idPeriodes,
+                String[] idEtablissements, String[] idMatieres, Boolean hasCompetences, Boolean historise) {
+        Promise<JsonArray> promise = Promise.promise();
+        listDevoirs(idEleve, idGroupes, idDevoirs, idPeriodes, idEtablissements, idMatieres, hasCompetences, historise,
+                FutureHelper.handlerJsonArray(promise.future()));
+        return promise.future();
+    }
+
+    @Override
     public void listDevoirsWithAnnotations(String idEleve, Long idPeriode, String idMatiere,
                                            Handler<Either<String, JsonArray>> handler) {
         JsonObject action = new JsonObject()

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
@@ -2075,7 +2075,8 @@ public class DefaultExportService implements ExportService {
                                         }
                                     }
                                 }
-                                if (null != params.get(Field.SKILLS) && Boolean.parseBoolean(params.get(Field.SKILLS))){
+                                boolean showSkills = null != params.get(Field.SKILLS) && Boolean.parseBoolean(params.get(Field.SKILLS));
+                                if (showSkills){
                                     JsonObject compNotesByMatiere = formatJsonObjectExportReleve(false, true, idUser, devoirsMap,
                                             maitrisesMap, competencesMap, matieresMap, competenceNotesMap);
 
@@ -2101,15 +2102,15 @@ public class DefaultExportService implements ExportService {
                                         });
                                     });
                                 }
+                                boolean showScores = null != params.get(Field.SCORES) && Boolean.parseBoolean(params.get(Field.SCORES));
                                 getEnseignantsMatieres(matieres, idEnseignants, devoirsJSON, periodeJSON, userJSON, etabJSON,
-                                        finalBackUp, moyennesFinales, multiTeachers, services, handler);
+                                        finalBackUp, moyennesFinales, multiTeachers, services, showScores, showSkills, handler);
 
 
                             });
                     })
                     .onFailure(error -> {
                         Utils.returnFailure("getExportReleveEleve : No informations about the student", event, handler);
-                        return;
                     });
                 }
             });
@@ -2126,13 +2127,15 @@ public class DefaultExportService implements ExportService {
      * @param periodeJson la periode
      * @param userJson    l'élève
      * @param etabJson    l'établissement
+     * @param showScores  if we want to show scores area.
+     * @param showSkills  if we want to show skills area.
      * @param handler
      */
     public void getEnseignantsMatieres(final JsonArray matieres, JsonArray idEnseignants, final JsonArray devoirsJson,
                                        final JsonObject periodeJson, final JsonObject userJson,
                                        final JsonObject etabJson, final boolean isBackup, final JsonArray moyennesFinales,
-                                       final JsonArray multiTeachers, final List<Service> services,
-                                       Handler<Either<String, JsonObject>> handler) {
+                                       final JsonArray multiTeachers, final List<Service> services, boolean showScores,
+                                       boolean showSkills, Handler<Either<String, JsonObject>> handler) {
         JsonObject action = new JsonObject()
                 .put(ACTION, "eleve.getUsers")
                 .put("idUsers", idEnseignants);
@@ -2147,9 +2150,12 @@ public class DefaultExportService implements ExportService {
                     JsonObject matiere = matieres.getJsonObject(k);
                     String idMatiere = matiere.getString("id");
 
+                    matiere.put(Field.SHOWSCORES, showScores)
+                            .put(Field.SHOWSKILLS, showSkills);
+
                     int rowspan = matiere.getJsonArray("sous_matieres").size();
                     matiere.put("rowspan", rowspan);
-                    if(rowspan > 0 && !printSousMatiere) {
+                    if(rowspan > 0 && !printSousMatiere && showScores) {
                         printSousMatiere = true;
                     }
 

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
@@ -1236,7 +1236,7 @@ public class DefaultExportService implements ExportService {
             }
             JsonObject competenceNote = new JsonObject();
             competenceNote.put(Field.HEADER, competencesInDomain.getKey());
-            competenceNote.put(Field.COMPETENCENOTES, calcWidthNote(text, usePerso, maitrises, valuesByComp, devoirs.size()));
+            competenceNote.put(Field.COMPETENCENOTES, calcWidthNote(text, usePerso, maitrises, valuesByComp, valuesByComp.size()));
             competencesInDomainArray.add(competenceNote);
             competencesArray.add(competenceNote);
         }
@@ -1386,7 +1386,7 @@ public class DefaultExportService implements ExportService {
             if(usePerso && !text)
                 competenceNotesObj.put("persoColor", maitrises.get(String.valueOf(notesMaitrises.getKey())).getString("couleur"));
 
-            competenceNotesObj.put("width", "1");
+            competenceNotesObj.put("width", (notesMaitrises.getValue() * 100 / nbDevoir));
 
             resultList.add(competenceNotesObj);
         }

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
@@ -2155,9 +2155,19 @@ public class DefaultExportService implements ExportService {
             if (OK.equals(body.getString(STATUS))) {
                 JsonArray users = body.getJsonArray(RESULTS);
                 boolean printSousMatiere = false;
+                JsonArray subjects;
 
-                for (int k = 0; k < matieres.size(); k++) {
-                    JsonObject matiere = matieres.getJsonObject(k);
+                if(null != matieres && !matieres.isEmpty() && showSkills && !showScores) {
+                    subjects = new JsonArray(matieres.stream()
+                            .filter(matiere -> ((JsonObject)matiere).getBoolean(Field.HASCOMPETENCESNOTES))
+                            .collect(Collectors.toList()));
+                }
+                else {
+                    subjects = matieres;
+                }
+
+                for (int k = 0; k < subjects.size(); k++) {
+                    JsonObject matiere = subjects.getJsonObject(k);
                     String idMatiere = matiere.getString("id");
 
                     matiere.put(Field.SHOWSCORES, showScores)
@@ -2226,7 +2236,7 @@ public class DefaultExportService implements ExportService {
 
                 final JsonObject templateProps = new JsonObject();
 
-                templateProps.put("matieres", matieres);
+                templateProps.put("matieres", subjects);
                 templateProps.put("periode", periodeJson);
                 String prefixPdfName = "releve-eleve";
                 if(isBackup) {

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
@@ -1386,7 +1386,8 @@ public class DefaultExportService implements ExportService {
             if(usePerso && !text)
                 competenceNotesObj.put("persoColor", maitrises.get(String.valueOf(notesMaitrises.getKey())).getString("couleur"));
 
-            competenceNotesObj.put("width", (notesMaitrises.getValue() * 100 / nbDevoir));
+            double notesMaitrisesValue = notesMaitrises.getValue() != null ? notesMaitrises.getValue() : 0;
+            competenceNotesObj.put("width", Math.floor(notesMaitrisesValue * 100 / nbDevoir));
 
             resultList.add(competenceNotesObj);
         }

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
@@ -2092,7 +2092,7 @@ public class DefaultExportService implements ExportService {
                         JsonObject result = new JsonObject();
                         noteService.calculPositionnementAutoByEleveByMatiere(competencesNotesBySubject.get(m.getString(Field.ID)), result, false, tableauDeConversionFuture.result(),
                                 null, null, isAvgSkillFuture.result());
-                        JsonObject positionnement = (JsonObject) result.getJsonArray(Field.POSITIONNEMENTS_AUTO).stream()
+                        JsonObject positionnement = (JsonObject) result.getJsonArray(POSITIONNEMENTS_AUTO).stream()
                                 .filter(pos -> periodId.equals(((JsonObject) pos).getLong(Field.ID_PERIODE)))
                                 .findFirst().orElse(null);
                         if (null != positionnement)

--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
@@ -1207,17 +1207,11 @@ public class DefaultExportService implements ExportService {
         return result;
     }
 
-    private void setCompetenceNoteItem(Boolean text, Boolean usePerso, Map<String, JsonObject> maitrises, Map<String, JsonObject> matieres, Map<String, Map<String, Long>> competenceNotesByDevoir, JsonArray competencesArray, Map<String, Set<String>> competencesByMatiere, Map<String, List<String>> devoirByCompetences) {
-        for (Map.Entry<String, Set<String>> competencesInDomain : competencesByMatiere.entrySet()) {
-            JsonObject domainObj = new JsonObject();
-            if (matieres.get(competencesInDomain.getKey()) != null) {
-                domainObj.put(Field.DOMAINHEADER, matieres.get(competencesInDomain.getKey())
-                        .getString(Field.NAME));
-            }
-
-            JsonArray competencesInDomainArray = new JsonArray();
+    private void setCompetenceNoteItem(Boolean text, Boolean usePerso, Map<String, JsonObject> maitrises, Map<String, JsonObject> matieres, Map<String, Map<String, Long>> competenceNotesByDevoir, JsonArray competencesArray, Map<String, Set<String>> competencesBySubject, Map<String, List<String>> devoirByCompetences) {
+        for (Map.Entry<String, Set<String>> competencesInSubject : competencesBySubject.entrySet()) {
+            JsonArray competencesInSubjectArray = new JsonArray();
             List<Long> valuesByComp = new ArrayList<>();
-            for (String competenceId : competencesInDomain.getValue()) {
+            for (String competenceId : competencesInSubject.getValue()) {
                 for (String devoir : devoirByCompetences.get(competenceId)) {
                     if (competenceNotesByDevoir.containsKey(devoir) && competenceNotesByDevoir.get(devoir)
                             .containsKey(competenceId)) {
@@ -1228,9 +1222,9 @@ public class DefaultExportService implements ExportService {
                 }
             }
             JsonObject competenceNote = new JsonObject();
-            competenceNote.put(Field.HEADER, competencesInDomain.getKey());
+            competenceNote.put(Field.HEADER, competencesInSubject.getKey());
             competenceNote.put(Field.COMPETENCENOTES, calcWidthNote(text, usePerso, maitrises, valuesByComp, valuesByComp.size()));
-            competencesInDomainArray.add(competenceNote);
+            competencesInSubjectArray.add(competenceNote);
             competencesArray.add(competenceNote);
         }
     }
@@ -2098,8 +2092,8 @@ public class DefaultExportService implements ExportService {
                         JsonObject result = new JsonObject();
                         noteService.calculPositionnementAutoByEleveByMatiere(competencesNotesBySubject.get(m.getString(Field.ID)), result, false, tableauDeConversionFuture.result(),
                                 null, null, isAvgSkillFuture.result());
-                        JsonObject positionnement = (JsonObject) result.getJsonArray("positionnements_auto").stream()
-                                .filter(pos -> periodId.equals(((JsonObject) pos).getLong("id_periode")))
+                        JsonObject positionnement = (JsonObject) result.getJsonArray(Field.POSITIONNEMENTS_AUTO).stream()
+                                .filter(pos -> periodId.equals(((JsonObject) pos).getLong(Field.ID_PERIODE)))
                                 .findFirst().orElse(null);
                         if (null != positionnement)
                             m.put(Field.POSITIONNEMENT, positionnement.getLong(Field.MOYENNE));

--- a/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
@@ -508,29 +508,29 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         }
     }
 
-    public void getCompetencesNotesReleveEleves(JsonArray ids, String etablissementId, String matiereId,
-                                                 JsonArray matiereIds,
-                                                 Long periodeId,  String eleveId, Boolean withDomaineInfo,
-                                                 Boolean isYear, Handler<Either<String, JsonArray>> handler) {
+    public void getCompetencesNotesReleveEleves(JsonArray studentIds, String structureIds, String subjectId,
+                                                JsonArray subjectIds,
+                                                Long periodId, String studentId, Boolean withDomainInfo,
+                                                Boolean isYear, Handler<Either<String, JsonArray>> handler) {
         List<String> idEleves = new ArrayList<String>();
 
-        if (ids != null) {
-            for (int i = 0; i < ids.size(); i++) {
-                idEleves.add(ids.getString(i));
+        if (studentIds != null) {
+            for (int i = 0; i < studentIds.size(); i++) {
+                idEleves.add(studentIds.getString(i));
             }
         }
 
         List<String> idMatieres = new ArrayList<String>();
 
-        if (matiereIds != null) {
-            for (int i = 0; i < matiereIds.size(); i++) {
-                idMatieres.add(matiereIds.getString(i));
+        if (subjectIds != null) {
+            for (int i = 0; i < subjectIds.size(); i++) {
+                idMatieres.add(subjectIds.getString(i));
             }
         } else{
             idMatieres = null;
         }
-        runGetCompetencesNotesReleve(etablissementId, matiereId, idMatieres, periodeId,
-                eleveId, idEleves, withDomaineInfo, isYear, handler);
+        runGetCompetencesNotesReleve(structureIds, subjectId, idMatieres, periodId,
+                studentId, idEleves, withDomainInfo, isYear, handler);
     }
 
     private Future<JsonArray> getCompetencesNotesReleveStudents(JsonArray ids, String structureId, String subjectId,

--- a/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
@@ -508,7 +508,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         }
     }
 
-    private void getCompetencesNotesReleveEleves(JsonArray ids, String etablissementId, String matiereId,
+    public void getCompetencesNotesReleveEleves(JsonArray ids, String etablissementId, String matiereId,
                                                  JsonArray matiereIds,
                                                  Long periodeId,  String eleveId, Boolean withDomaineInfo,
                                                  Boolean isYear, Handler<Either<String, JsonArray>> handler) {

--- a/src/main/java/fr/openent/competences/service/impl/DefaultUtilsService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultUtilsService.java
@@ -703,6 +703,27 @@ public class DefaultUtilsService implements UtilsService {
         Sql.getInstance().prepared(query.toString(), params, SqlResult.validUniqueResultHandler(handler));
     }
 
+    @Override
+    public Future<JsonObject> getCycle(String idClasse) {
+        Promise<JsonObject> cyclePromise = Promise.promise();
+        getCycle(idClasse, FutureHelper.handlerJsonObject(cyclePromise));
+        return cyclePromise.future();
+    }
+
+    /*@Override
+    public Future<JsonObject> getCycle(String idClasse) {
+        Promise<JsonObject> promise = Promise.promise();
+        this.getCycle(idClasse, result -> {
+            if (result.isRight()) {
+                promise.complete(result.right().getValue());
+            }
+            else {
+                promise.fail(result.left().getValue());
+            }
+        });
+        return promise.future();
+    }*/
+
 
     private Handler<Message<JsonObject>> nameHandler(String[] name, String field,
                                                      Handler<Either<String, JsonArray>> handler){

--- a/src/main/java/fr/openent/competences/service/impl/DefaultUtilsService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultUtilsService.java
@@ -710,21 +710,6 @@ public class DefaultUtilsService implements UtilsService {
         return cyclePromise.future();
     }
 
-    /*@Override
-    public Future<JsonObject> getCycle(String idClasse) {
-        Promise<JsonObject> promise = Promise.promise();
-        this.getCycle(idClasse, result -> {
-            if (result.isRight()) {
-                promise.complete(result.right().getValue());
-            }
-            else {
-                promise.fail(result.left().getValue());
-            }
-        });
-        return promise.future();
-    }*/
-
-
     private Handler<Message<JsonObject>> nameHandler(String[] name, String field,
                                                      Handler<Either<String, JsonArray>> handler){
         return event -> {

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -12,6 +12,5 @@
 	"competences.memento.widget.subject.detail.no.notes": "There are no ratings for the selected filters",
 	"competences.memento.notes.init.failed": "An error occurred while loading the notes widget",
 	"competences.report-model.api.error.remove": "An error occurred when deleting a model",
-
 	"evaluations.class.report.scores.and.skills": "Scores and skills"
 }

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -11,5 +11,7 @@
 	"competences.memento.widget.average.subjects.no.notes": "There is no note for this period",
 	"competences.memento.widget.subject.detail.no.notes": "There are no ratings for the selected filters",
 	"competences.memento.notes.init.failed": "An error occurred while loading the notes widget",
-	"competences.report-model.api.error.remove": "An error occurred when deleting a model"
+	"competences.report-model.api.error.remove": "An error occurred when deleting a model",
+
+	"evaluations.class.report.scores.and.skills": "Scores and skills"
 }

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -627,6 +627,7 @@
   "evaluations.export.bulletin.viescolaireLibelle": "Vie scolaire (assiduité, ponctualité; respect du règlement intérieur; participation à la vie de l'établissement) : ",
   "evaluations.choose.classe": "Veuillez sélectionner au moins une classe et une période",
   "evaluations.classes.are.not.initialized": "Désolé, les classes sélectionnée non pas de périodes paramétrées",
+  "evaluations.class.report.scores.and.skills": "Notes et compétences",
   "evaluations.graph.formative" : "* (F) : Evaluation de type Formative",
   "evaluations.graph.go.list" : "Accéder à la vue Liste",
   "evaluations.tab.delete" : "Supprimer une évaluation libre",

--- a/src/main/resources/public/template/enseignants/suivi_competences_classe/content.html
+++ b/src/main/resources/public/template/enseignants/suivi_competences_classe/content.html
@@ -46,9 +46,21 @@
             <input type="radio" ng-change="changePrintSuiviClasse('printRecapAppreciations')"  ng-model="suiviClasse.print" value="printRecapAppreciations">
             <span><i18n>evaluations.recapAppreciations.classe</i18n></span>
         </label>
-        <label>
-            <input type="radio" ng-change="changePrintSuiviClasse('printClasseReleve')" ng-model="suiviClasse.print" value="printClasseReleve">
-            <span><i18n>evaluation.releve.classe</i18n></span>
+        <label class="flex-row gap-24">
+            <div>
+                <input type="radio" ng-change="changePrintSuiviClasse('printClasseReleve')" ng-model="suiviClasse.print" value="printClasseReleve">
+                <span><i18n>evaluation.releve.classe</i18n></span>
+            </div>
+            <select ng-show="suiviClasse.print === PRINT_OPTIONS.PRINT_CLASS_REPORT"
+                    ng-model="suiviClasse.classReportUriOption">
+                <option ng-value="CLASS_REPORT_URI_OPTIONS.SCORES">
+                    [[translate(evaluation.bilan.periodique.graphiques.notes)]]
+                </option>
+                <option ng-value="CLASS_REPORT_URI_OPTIONS.SKILLS">[[translate(competences.title)]]</option>
+                <option ng-value="CLASS_REPORT_URI_OPTIONS.SCORES_AND_SKILLS">
+                    [[translate(evaluations.class.report.scores.and.skills)]]
+                </option>
+            </select>
         </label>
         <div class="checkbox-grid"
              ng-if="isChefEtabOrHeadTeacher(informations.classe) || isPersEducNat()">
@@ -234,7 +246,7 @@
         <button class="right-magnet"
                 ng-disabled = "disabledExportSuiviClasseButton() || positioningCsvData"
                 ng-click="exportRecapEval(suiviClasse.textMod, suiviClasse.print, suiviClasse.periode.id_type,
-                suiviClasse.exportByEnseignement, suiviClasse.withMoyGeneraleByEleve, suiviClasse.withMoyMinMaxByMat)">
+                suiviClasse.exportByEnseignement, suiviClasse.withMoyGeneraleByEleve, suiviClasse.withMoyMinMaxByMat, suiviClasse)">
             <i18n>evaluations.export</i18n>
         </button>
     </div>

--- a/src/main/resources/public/template/enseignants/suivi_competences_classe/content.html
+++ b/src/main/resources/public/template/enseignants/suivi_competences_classe/content.html
@@ -54,11 +54,11 @@
             <select ng-show="suiviClasse.print === PRINT_OPTIONS.PRINT_CLASS_REPORT"
                     ng-model="suiviClasse.classReportUriOption">
                 <option ng-value="CLASS_REPORT_URI_OPTIONS.SCORES">
-                    [[translate(evaluation.bilan.periodique.graphiques.notes)]]
+                    [[translate('evaluation.bilan.periodique.graphiques.notes')]]
                 </option>
-                <option ng-value="CLASS_REPORT_URI_OPTIONS.SKILLS">[[translate(competences.title)]]</option>
+                <option ng-value="CLASS_REPORT_URI_OPTIONS.SKILLS">[[translate('competences.title')]]</option>
                 <option ng-value="CLASS_REPORT_URI_OPTIONS.SCORES_AND_SKILLS">
-                    [[translate(evaluations.class.report.scores.and.skills)]]
+                    [[translate('evaluations.class.report.scores.and.skills')]]
                 </option>
             </select>
         </label>

--- a/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
@@ -118,7 +118,6 @@
             border: none !important;
             border-left: solid 1px #000 !important;
             border-bottom: solid 1px #000 !important;
-            border-right: solid 1px #000 !important;
         }
 
         .professeur {
@@ -274,6 +273,10 @@
                     </tr>
                 </table>
             </td>
+            <td class="align-left border-right-bottom">
+                <span>Pos</span>
+                <div>{{ positionnement }}</div>
+            </td>
         </tr>
         {{/hasCompetencesNotes}}
         {{/matieres}}
@@ -392,7 +395,7 @@
         {{/sous_matieres_tail}}
         {{#hasCompetencesNotes}}
         <tr>
-            <td rowspan="{{rowspan}}" colspan="5" class="align-left competence">
+            <td rowspan="{{rowspan}}" colspan="4" class="align-left competence">
                 <span class="align-left">Bilan des items</span>
                 <table>
                     <tr>
@@ -403,6 +406,10 @@
                         {{/ competencesNotes }}
                     </tr>
                 </table>
+            </td>
+            <td class="align-left border-right-bottom">
+                <span>Pos</span>
+                <div>{{ positionnement }}</div>
             </td>
         </tr>
         {{/hasCompetencesNotes}}

--- a/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
@@ -16,7 +16,8 @@
   ~   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   -->
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <title>Relevé de notes</title>
@@ -68,13 +69,13 @@
         }
 
         .head tr td:first-child {
-            min-width : 60%;
+            min-width: 60%;
             width: 60%;
             max-width: 60%;
         }
 
         .head tr td:last-child {
-            min-width : 40%;
+            min-width: 40%;
             width: 40%;
             max-width: 40%;
         }
@@ -122,7 +123,6 @@
         }
 
         .competence {
-            border: none !important;
             border-left: solid 1px #000 !important;
             border-bottom: solid 1px #000 !important;
         }
@@ -174,25 +174,45 @@
             font-size: 70%;
         }
 
-        .note{
+        .note {
             font-weight: bold;
             font-size: 90%;
         }
 
-        .coeff{
+        .coeff {
             font-size: 70%;
         }
 
         .div-note {
             width: 30px;
         }
+
+        .table {
+            display: table;
+        }
+
         .bars-skills-evaluation {
             padding: 10px;
+            display: table-cell;
+            vertical-align: middle;
+            text-align: center;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+
+        .bar-skill-piece {
             display: inline-block;
+            margin-right: -4px;
+        }
+
+        .positioning {
+            display: table-cell;
+            vertical-align: middle;
             text-align: center;
         }
+
     </style>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8"/>
 </head>
 <body>
 
@@ -221,9 +241,9 @@
     <table class="display-bulletin">
         {{#printSousMatiere}}
         <colgroup>
-            <col span="2" class="width-20" />
-            <col class="width-40" />
-            <col span="2" class="width-10" />
+            <col span="2" class="width-20"/>
+            <col class="width-40"/>
+            <col span="2" class="width-10"/>
         </colgroup>
         <tr class="greyscale entete-1">
             <td class="border-left" colspan="2"><strong>Matière</strong></td>
@@ -277,17 +297,23 @@
         {{#showSkills}}
         {{#hasCompetencesNotes}}
         <tr>
-            <td class="align-left competence" colspan="2">
-                <span class="align-left">Bilan des items</span>
-                <div class="bars-skills-evaluation width-90">
-                    {{# competencesNotes }}
-                    <div style="float: left; display: inline-block; width: {{width}}%; background-color: {{ persoColor }} !important">{{ number }}</div>
-                    {{/ competencesNotes }}
+            <td class="competence align-left border-right width-100">
+                <div>Bilan des items</div>
+                <div class="table width-100">
+                    <div class="bars-skills-evaluation width-90">
+                        {{# competencesNotes }}
+                        <div class="bar-skill-piece"
+                             style="width: {{width}}%; background-color: {{ persoColor }} !important">{{ number }}
+                        </div>
+                        {{/ competencesNotes }}
+                    </div>
+                    <div class="positioning">
+                        <span class="align-left width-100">Position</span>
+                        <span class="width-100">
+                        {{ positionnement }}
+                    </span>
+                    </div>
                 </div>
-            </td>
-            <td class="align-left border-right-bottom">
-                <span>Pos</span>
-                <div>{{ positionnement }}</div>
             </td>
         </tr>
         {{/hasCompetencesNotes}}
@@ -310,7 +336,7 @@
             {{#first_sous_matieres}}
             {{#isLast}}
             <td class="sousMat border-bottom">
-                <div  style="width: 40px">
+                <div style="width: 40px">
                     <span class="pretty center">{{libelle}}
                         <sup class="coeff">{{coeff}}</sup>
                     </span>
@@ -331,7 +357,7 @@
             {{/isLast}}
             {{^isLast}}
             <td class="sousMat">
-                <div  style="width: 40px">
+                <div style="width: 40px">
                     <span class="pretty center">{{libelle}}   <sup class="coeff">{{coeff}}</sup></span></div>
             </td>
             <td class="border-left border-right">
@@ -378,7 +404,7 @@
         <tr>
             {{^isLast}}
             <td class="sousMat">
-                <div  style="width: 40px">
+                <div style="width: 40px">
                     <span class="pretty center">{{libelle}}   <sup class="coeff">{{coeff}}</sup></span></div>
             </td>
             <td class="border-left border-right">
@@ -392,7 +418,7 @@
             {{/isLast}}
             {{#isLast}}
             <td class="sousMat border-bottom">
-                <div  style="width: 40px">
+                <div style="width: 40px">
                     <span class="pretty center">{{libelle}}   <sup class="coeff">{{coeff}}</sup></span></div>
             </td>
             <td class="border-left-right-bottom">
@@ -409,17 +435,23 @@
         {{#showSkills}}
         {{#hasCompetencesNotes}}
         <tr>
-            <td class="align-left competence" colspan="4">
-                <span class="align-left">Bilan des items</span>
-                <div class="bars-skills-evaluation width-90">
-                    {{# competencesNotes }}
-                    <div style="float: left; display: inline-block; width: {{width}}%; background-color: {{ persoColor }} !important">{{ number }}</div>
-                    {{/ competencesNotes }}
+            <td class="competence align-left border-right" colspan="5">
+                <span>Bilan des items</span>
+                <div class="table width-100">
+                    <div class="bars-skills-evaluation width-90">
+                        {{# competencesNotes }}
+                        <div class="bar-skill-piece"
+                             style="width: {{width}}%; background-color: {{ persoColor }} !important">{{ number }}
+                        </div>
+                        {{/ competencesNotes }}
+                    </div>
+                    <div class="positioning">
+                        <span class="align-left width-100">Position</span>
+                        <span class="width-100">
+                        {{ positionnement }}
+                    </span>
+                    </div>
                 </div>
-            </td>
-            <td class="align-left border-right-bottom">
-                <span>Pos</span>
-                <div>{{ positionnement }}</div>
             </td>
         </tr>
         {{/hasCompetencesNotes}}

--- a/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
@@ -260,20 +260,22 @@
                 {{/hasDiviseurMatiere}}{{/moyenne_non_note}}
             </td>
         </tr>
-        {{# competencesNotes }}
+        {{#hasCompetencesNotes}}
         <tr>
-            <td rowspan="{{rowspan}}" colspan="5" class="align-left competence">
+            <td rowspan="{{rowspan}}" colspan="3" class="align-left competence">
                 <span class="align-left">Bilan des items</span>
                 <table>
                     <tr>
+                        {{# competencesNotes }}
                         <td>
                             <div style="background-color: {{ persoColor }} !important">{{ number }}</div>
                         </td>
+                        {{/ competencesNotes }}
                     </tr>
                 </table>
             </td>
         </tr>
-        {{/ competencesNotes }}
+        {{/hasCompetencesNotes}}
         {{/matieres}}
         {{/printSousMatiere}}
 
@@ -388,20 +390,22 @@
             {{/isLast}}
         </tr>
         {{/sous_matieres_tail}}
-        {{# competencesNotes }}
+        {{#hasCompetencesNotes}}
         <tr>
             <td rowspan="{{rowspan}}" colspan="5" class="align-left competence">
                 <span class="align-left">Bilan des items</span>
                 <table>
                     <tr>
+                        {{# competencesNotes }}
                         <td>
                             <div style="background-color: {{ persoColor }} !important">{{ number }}</div>
                         </td>
+                        {{/ competencesNotes }}
                     </tr>
                 </table>
             </td>
         </tr>
-        {{/ competencesNotes }}
+        {{/hasCompetencesNotes}}
         {{/matieres}}
         {{/printSousMatiere}}
     </table>

--- a/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
@@ -114,6 +114,13 @@
             border-bottom: solid 1px #000 !important;
         }
 
+        .competence {
+            border: none !important;
+            border-left: solid 1px #000 !important;
+            border-bottom: solid 1px #000 !important;
+            border-right: solid 1px #000 !important;
+        }
+
         .professeur {
             border: none !important;
             font-size: 10px;
@@ -172,6 +179,10 @@
 
         .div-note {
             width: 30px;
+        }
+        .barEvaluation td {
+            margin: auto;
+            padding: 0px;
         }
     </style>
     <meta charset="UTF-8" />
@@ -249,6 +260,20 @@
                 {{/hasDiviseurMatiere}}{{/moyenne_non_note}}
             </td>
         </tr>
+        {{# competencesNotes }}
+        <tr>
+            <td rowspan="{{rowspan}}" colspan="5" class="align-left competence">
+                <span class="align-left">Bilan des items</span>
+                <table>
+                    <tr>
+                        <td>
+                            <div style="background-color: {{ persoColor }} !important">{{ number }}</div>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        {{/ competencesNotes }}
         {{/matieres}}
         {{/printSousMatiere}}
 
@@ -363,6 +388,20 @@
             {{/isLast}}
         </tr>
         {{/sous_matieres_tail}}
+        {{# competencesNotes }}
+        <tr>
+            <td rowspan="{{rowspan}}" colspan="5" class="align-left competence">
+                <span class="align-left">Bilan des items</span>
+                <table>
+                    <tr>
+                        <td>
+                            <div style="background-color: {{ persoColor }} !important">{{ number }}</div>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        {{/ competencesNotes }}
         {{/matieres}}
         {{/printSousMatiere}}
     </table>

--- a/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
@@ -91,6 +91,14 @@
             width: 40%;
         }
 
+        .width-80 {
+            width: 80%;
+        }
+
+        .width-100 {
+            width: 100%;
+        }
+
         .greyscale {
             background-color: #f0f0f0;
         }
@@ -109,7 +117,6 @@
         }
 
         .matiere {
-            border: none !important;
             border-left: solid 1px #000 !important;
             border-bottom: solid 1px #000 !important;
         }
@@ -179,9 +186,10 @@
         .div-note {
             width: 30px;
         }
-        .barEvaluation td {
-            margin: auto;
-            padding: 0px;
+        .bars-skills-evaluation {
+            display: flex;
+            padding: 10px;
+            text-align: center;
         }
     </style>
     <meta charset="UTF-8" />
@@ -225,9 +233,14 @@
         {{/printSousMatiere}}
         {{^printSousMatiere}}
         <tr class="greyscale entete-1">
+            {{^showScores}}
+            <td class="border-left border-right width-100"><strong>Matière</strong></td>
+            {{/showScores}}
+            {{#showScores}}
             <td class="border-left width-40"><strong>Matière</strong></td>
             <td class="border-left-right-bottom width-40"><strong>Notes</strong></td>
             <td class="border-right-bottom width-20"><strong>Moyenne</strong></td>
+            {{/showScores}}
         </tr>
         {{/printSousMatiere}}
 
@@ -235,7 +248,7 @@
         {{^printSousMatiere}}
         {{#matieres}}
         <tr>
-            <td class="upper align-left matiere">
+            <td class="upper align-left matiere border-right">
                 <span class="align-left">{{name}}</span>
                 <span class="align-left professeur">
                 {{#displayNameEnseignant}}
@@ -243,7 +256,8 @@
                 {{/displayNameEnseignant}}
             </span>
             </td>
-            <td class="border-left-right-bottom">
+            {{#showScores}}
+            <td class="border-right-bottom">
                 {{#devoirs}}
                 <span class="div-note">
             <span class="note">{{note}}</span>
@@ -258,20 +272,18 @@
                 <span class="diviseur">/20</span>
                 {{/hasDiviseurMatiere}}{{/moyenne_non_note}}
             </td>
+            {{/showScores}}
         </tr>
+        {{#showSkills}}
         {{#hasCompetencesNotes}}
         <tr>
-            <td rowspan="{{rowspan}}" colspan="3" class="align-left competence">
+            <td class="align-left competence width-80">
                 <span class="align-left">Bilan des items</span>
-                <table>
-                    <tr>
-                        {{# competencesNotes }}
-                        <td>
-                            <div style="background-color: {{ persoColor }} !important">{{ number }}</div>
-                        </td>
-                        {{/ competencesNotes }}
-                    </tr>
-                </table>
+                <div class="bars-skills-evaluation width-100">
+                    {{# competencesNotes }}
+                    <div style="flex: 1; background-color: {{ persoColor }} !important">{{ number }}</div>
+                    {{/ competencesNotes }}
+                </div>
             </td>
             <td class="align-left border-right-bottom">
                 <span>Pos</span>
@@ -279,6 +291,7 @@
             </td>
         </tr>
         {{/hasCompetencesNotes}}
+        {{/showSkills}}
         {{/matieres}}
         {{/printSousMatiere}}
 
@@ -393,19 +406,16 @@
             {{/isLast}}
         </tr>
         {{/sous_matieres_tail}}
+        {{#showSkills}}
         {{#hasCompetencesNotes}}
         <tr>
-            <td rowspan="{{rowspan}}" colspan="4" class="align-left competence">
+            <td class="align-left competence" colspan="4">
                 <span class="align-left">Bilan des items</span>
-                <table>
-                    <tr>
-                        {{# competencesNotes }}
-                        <td>
-                            <div style="background-color: {{ persoColor }} !important">{{ number }}</div>
-                        </td>
-                        {{/ competencesNotes }}
-                    </tr>
-                </table>
+                <div class="bars-skills-evaluation width-100">
+                    {{# competencesNotes }}
+                    <div style="flex: 1; background-color: {{ persoColor }} !important">{{ number }}</div>
+                    {{/ competencesNotes }}
+                </div>
             </td>
             <td class="align-left border-right-bottom">
                 <span>Pos</span>
@@ -413,6 +423,7 @@
             </td>
         </tr>
         {{/hasCompetencesNotes}}
+        {{/showSkills}}
         {{/matieres}}
         {{/printSousMatiere}}
     </table>

--- a/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
@@ -91,8 +91,8 @@
             width: 40%;
         }
 
-        .width-80 {
-            width: 80%;
+        .width-90 {
+            width: 90%;
         }
 
         .width-100 {
@@ -187,8 +187,8 @@
             width: 30px;
         }
         .bars-skills-evaluation {
-            display: flex;
             padding: 10px;
+            display: inline-block;
             text-align: center;
         }
     </style>
@@ -277,11 +277,11 @@
         {{#showSkills}}
         {{#hasCompetencesNotes}}
         <tr>
-            <td class="align-left competence width-80">
+            <td class="align-left competence" colspan="2">
                 <span class="align-left">Bilan des items</span>
-                <div class="bars-skills-evaluation width-100">
+                <div class="bars-skills-evaluation width-90">
                     {{# competencesNotes }}
-                    <div style="flex: 1; background-color: {{ persoColor }} !important">{{ number }}</div>
+                    <div style="float: left; display: inline-block; width: {{width}}%; background-color: {{ persoColor }} !important">{{ number }}</div>
                     {{/ competencesNotes }}
                 </div>
             </td>
@@ -411,9 +411,9 @@
         <tr>
             <td class="align-left competence" colspan="4">
                 <span class="align-left">Bilan des items</span>
-                <div class="bars-skills-evaluation width-100">
+                <div class="bars-skills-evaluation width-90">
                     {{# competencesNotes }}
-                    <div style="flex: 1; background-color: {{ persoColor }} !important">{{ number }}</div>
+                    <div style="float: left; display: inline-block; width: {{width}}%; background-color: {{ persoColor }} !important">{{ number }}</div>
                     {{/ competencesNotes }}
                 </div>
             </td>

--- a/src/main/resources/public/ts/controllers/eval_suivi_competences_classe_ctl.ts
+++ b/src/main/resources/public/ts/controllers/eval_suivi_competences_classe_ctl.ts
@@ -22,7 +22,7 @@
 
 import {$, http, idiom as lang, model, ng, notify, template} from 'entcore';
 import httpAxios from "axios";
-import {evaluations, Matiere, SuiviCompetenceClasse} from '../models/teacher';
+import {evaluations, IClassReport, Matiere, SuiviCompetenceClasse} from '../models/teacher';
 import * as utils from '../utils/teacher';
 import {Defaultcolors} from "../models/eval_niveau_comp";
 import {Utils} from "../models/teacher/";
@@ -292,7 +292,7 @@ export let evalSuiviCompetenceClasseCtl = ng.controller('EvalSuiviCompetenceClas
         let infoNameFileEnd;
         $scope.disabledExportFile = false;
         $scope.exportRecapEval = async (textMod, printSuiviClasse, idPeriode, exportByEnseignement,
-                                        withMoyGeneraleByEleve, withMoyMinMaxByMat) => {
+                                        withMoyGeneraleByEleve, withMoyMinMaxByMat, classReport?: IClassReport) => {
             infoNameFileEnd = `_${$scope.search.classe.name}`;
             $scope.errorWhenExportPdf = false;
             switch (printSuiviClasse) {
@@ -420,17 +420,12 @@ export let evalSuiviCompetenceClasseCtl = ng.controller('EvalSuiviCompetenceClas
                     $scope.exportRecapEvalObj.errExport = false;
                     await Utils.runMessageLoader($scope);
                     try {
-                        if (type_periode !== undefined) {
-                            await Utils.getClasseReleve(idPeriode, idClasse, type_periode.type, type_periode.ordre,
-                                idStructure, classeName);
-                        }
-                        else {
-                            await Utils.getClasseReleve(undefined, $scope.search.classe.id, undefined, undefined,
-                                idStructure, classeName);
-                        }
+                        await Utils.getClasseReleve(type_periode !== undefined ? idPeriode : undefined,
+                            idClasse, type_periode.type, type_periode.ordre,
+                            idStructure, classeName, classReport ? classReport.classReportUriOption : null);
+
                         await Utils.stopMessageLoader($scope);
-                    }
-                    catch (e) {
+                    } catch (e) {
                         await Utils.stopMessageLoader($scope);
                     }
                     break;

--- a/src/main/resources/public/ts/controllers/eval_teacher_ctl.ts
+++ b/src/main/resources/public/ts/controllers/eval_teacher_ctl.ts
@@ -22,7 +22,7 @@ import {
     evaluations,
     ReleveNote,
     ReleveNoteTotale,
-    Classe
+    Classe, IClassReport
 } from '../models/teacher';
 import * as utils from '../utils/teacher';
 import {Defaultcolors} from "../models/eval_niveau_comp";
@@ -41,6 +41,7 @@ import { LengthLimit} from "../constants/ConstantCommonLength"
 import {isValidClasse} from "../utils/functions/isValidClasse";
 import {isValidDevoir} from "../utils/filters/isValidDevoir";
 import {AppreciationSubjectPeriodStudent} from "../models/teacher/AppreciationSubjectPeriodStudent";
+import {CLASS_REPORT_URI_OPTIONS, PRINT_OPTIONS} from "../core/enum/print.enum";
 
 declare let $: any;
 declare let document: any;
@@ -485,6 +486,8 @@ export let evaluationsController = ng.controller('EvaluationsController', [
                 if (evaluations.structure !== undefined && evaluations.structure.isSynchronized) {
                     $scope.cleanRoot();
                     template.close('suivi-competence-content');
+                    $scope.PRINT_OPTIONS = PRINT_OPTIONS;
+                    $scope.CLASS_REPORT_URI_OPTIONS = CLASS_REPORT_URI_OPTIONS;
                     let display = async function(){
                         $scope.selected.matieres = [];
                         $scope.allUnselect = true;
@@ -493,7 +496,7 @@ export let evaluationsController = ng.controller('EvaluationsController', [
                         $scope.exportRecapEvalObj = {
                             errExport: false
                         };
-                        $scope.suiviClasse = {
+                        $scope.suiviClasse = <IClassReport>{
                             textMod: true,
                             exportByEnseignement: 'false',
                             withMoyGeneraleByEleve: true,
@@ -501,7 +504,8 @@ export let evaluationsController = ng.controller('EvaluationsController', [
                             withAppreciations: true,
                             withAvisConseil: true,
                             withAvisOrientation: true,
-                            print: 'printRecapEval'
+                            print: 'printRecapEval',
+                            classReportUriOption: CLASS_REPORT_URI_OPTIONS.SCORES,
                         };
                         $scope.disabledExportSuiviClasse = _.findIndex($scope.allMatieresSorted, {select: true}) === -1;
                         $scope.sortType = 'title'; // set the default sort type

--- a/src/main/resources/public/ts/core/enum/print.enum.ts
+++ b/src/main/resources/public/ts/core/enum/print.enum.ts
@@ -1,0 +1,10 @@
+export enum PRINT_OPTIONS {
+    PRINT_CLASS_REPORT = 'printClasseReleve',
+}
+
+
+export enum CLASS_REPORT_URI_OPTIONS {
+    SCORES = "scores=true",
+    SKILLS = "skills=true",
+    SCORES_AND_SKILLS = "scores=true&skills=true",
+}

--- a/src/main/resources/public/ts/models/teacher/SuiviCompetenceClasse.ts
+++ b/src/main/resources/public/ts/models/teacher/SuiviCompetenceClasse.ts
@@ -19,6 +19,19 @@ import {Collection, Model} from 'entcore';
 import {Classe, CompetenceNote, Domaine, Matiere, Periode, Structure, SuiviCompetence, Utils} from './index';
 import {Enseignement} from "../parent_eleve/Enseignement";
 import http from "axios";
+import {CLASS_REPORT_URI_OPTIONS} from "../../core/enum/print.enum";
+export interface IClassReport {
+
+    textMod: boolean,
+    exportByEnseignement: string,
+    withMoyGeneraleByEleve: boolean,
+    withMoyMinMaxByMat: boolean,
+    withAppreciations: boolean,
+    withAvisConseil: boolean,
+    withAvisOrientation: boolean,
+    print: string,
+    classReportUriOption: CLASS_REPORT_URI_OPTIONS,
+}
 
 export class SuiviCompetenceClasse extends Model {
     domaines : Collection<Domaine>;

--- a/src/main/resources/public/ts/models/teacher/Utils.ts
+++ b/src/main/resources/public/ts/models/teacher/Utils.ts
@@ -858,7 +858,8 @@ export class Utils {
                 idTypePeriode: idTypePeriode,
                 ordre: ordrePeriode,
                 idStructure: idStructure,
-                classeName: classeName
+                classeName: classeName,
+
             };
             if(Utils.isNull(idStructure) || Utils.isNull(idClasse)){
                 console.error(`[getClasseReleve] : required idStructure: ${idStructure} and idClasse: ${idClasse}`);

--- a/src/main/resources/public/ts/models/teacher/Utils.ts
+++ b/src/main/resources/public/ts/models/teacher/Utils.ts
@@ -849,8 +849,9 @@ export class Utils {
     static isNotDefault =  function (object) {
         return (object !== undefined) && (object !== null) && (object !== '*') && (object !== '');
     };
-    static getClasseReleve = async function(idPeriode, idClasse, idTypePeriode, ordrePeriode, idStructure, classeName){
-            let url = `/competences/releve/classe/pdf`;
+    static getClasseReleve = async function(idPeriode, idClasse, idTypePeriode, ordrePeriode, idStructure, classeName,
+                                            uriParams?: string){
+            let url = `/competences/releve/classe/pdf?${uriParams || ''}`;
             let param = {
                 idPeriode: idPeriode,
                 idClasse: idClasse,

--- a/src/main/resources/public/ts/models/teacher/Utils.ts
+++ b/src/main/resources/public/ts/models/teacher/Utils.ts
@@ -866,7 +866,7 @@ export class Utils {
                 return;
             }
             try {
-                let data = await http.post(url + `?idStructure=${param.idStructure}`, param,{responseType: 'arraybuffer'});
+                let data = await http.post(url + `&idStructure=${param.idStructure}`, param,{responseType: 'arraybuffer'});
 
                 let blob = new Blob([data.data]);
                 let link = document.createElement('a');


### PR DESCRIPTION
## Describe your changes
Adds the possibility to print skills results to Releve de notes in Suivi Class via a list letting you chose between skills, scores and both skills&scores.

## Checklist tests
Suivi classe -> Download button -> "Le relevé de notes des élèves de la classe" -> test "Notes" and "Notes et compétences"

## Issue ticket number and link
[EVAL-228](https://jira.support-ent.fr/browse/EVAL-228)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

