### PR TITLE
Fix(security): #EVAL-489 modify AccessStructureAndAdminOrTeacherCourseFilter and add structure id in front API post /structure/options/isSkillAverage 

### DIFF
--- a/src/main/java/fr/openent/competences/controllers/ElementBilanPeriodiqueController.java
+++ b/src/main/java/fr/openent/competences/controllers/ElementBilanPeriodiqueController.java
@@ -19,7 +19,7 @@ package fr.openent.competences.controllers;
 
 import fr.openent.competences.Competences;
 import fr.openent.competences.security.AccessElementBilanPeriodiqueFilter;
-import fr.openent.competences.security.AccessStructureAndAdminOrTeacherCourseFilter;
+import fr.openent.competences.security.AccessStructureAdminTeacherFilter;
 import fr.openent.competences.security.CreateElementBilanPeriodique;
 import fr.openent.competences.security.utils.AccessThematiqueBilanPeriodique;
 import fr.openent.competences.security.utils.WorkflowActionUtils;
@@ -521,7 +521,7 @@ public class ElementBilanPeriodiqueController extends ControllerHelper {
     @Get("/elementsAppreciations")
     @ApiDoc("Retourne les appreciations liées au élèments du bilan périodiques passés en paramètre")
     @SecuredAction(value = "", type = ActionType.RESOURCE)
-    @ResourceFilter(AccessStructureAndAdminOrTeacherCourseFilter.class)
+    @ResourceFilter(AccessStructureAdminTeacherFilter.class)
     public void getAppreciations(final HttpServerRequest request){
         UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
             @Override

--- a/src/main/java/fr/openent/competences/controllers/StructureOptionsController.java
+++ b/src/main/java/fr/openent/competences/controllers/StructureOptionsController.java
@@ -51,8 +51,8 @@ public class StructureOptionsController extends ControllerHelper {
 
     @Post("/structure/options/isSkillAverage")
     @ApiDoc(" create and update structure_options isSkillAverage")
-    @ResourceFilter(AdministratorRight.class)
     @SecuredAction(value = "", type= ActionType.RESOURCE)
+    @ResourceFilter(AdministratorRight.class)
     public void createOrUpdateIsAverageSkills (final HttpServerRequest request){
         UserUtils.getUserInfos(eb, request, user -> {
             if( user != null) {

--- a/src/main/java/fr/openent/competences/security/AccessStructureAdminTeacherFilter.java
+++ b/src/main/java/fr/openent/competences/security/AccessStructureAdminTeacherFilter.java
@@ -1,7 +1,6 @@
 package fr.openent.competences.security;
 
 import fr.openent.competences.constants.Field;
-import fr.openent.competences.security.utils.FilterUserUtils;
 import fr.openent.competences.security.utils.WorkflowActionUtils;
 import fr.openent.competences.security.utils.WorkflowActions;
 import fr.wseduc.webutils.http.Binding;
@@ -10,7 +9,7 @@ import io.vertx.core.http.HttpServerRequest;
 import org.entcore.common.http.filter.ResourcesProvider;
 import org.entcore.common.user.UserInfos;
 
-public class AccessStructureAndAdminOrTeacherCourseFilter implements ResourcesProvider {
+public class AccessStructureAdminTeacherFilter implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
         boolean isAdmin = WorkflowActionUtils.hasRight(user, WorkflowActions.ADMIN_RIGHT.toString());

--- a/src/main/java/fr/openent/competences/security/AccessStructureAndAdminOrTeacherCourseFilter.java
+++ b/src/main/java/fr/openent/competences/security/AccessStructureAndAdminOrTeacherCourseFilter.java
@@ -14,24 +14,8 @@ public class AccessStructureAndAdminOrTeacherCourseFilter implements ResourcesPr
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
         boolean isAdmin = WorkflowActionUtils.hasRight(user, WorkflowActions.ADMIN_RIGHT.toString());
-        boolean isInStructure = false;
-        boolean isTeacherWhomClassBelong = false;
-        FilterUserUtils filterUserUtils = new FilterUserUtils(user,null);
-
-        //Check if the user is in the structure
-        if(request.params().contains(Field.IDETABLISSEMENT)){
-            isInStructure = filterUserUtils.validateStructure(request.params().get(Field.IDETABLISSEMENT));
-        }
-
-        //Check if the user is a teacher, if yes check if the class belongs to this teacher
-        if (request.params().contains(Field.IDCLASSE)
-                && user.getType().equals(Field.TEACHER)) {
-            String idClass = request.params().get(Field.IDCLASSE);
-            isTeacherWhomClassBelong = filterUserUtils.validateClasse(idClass);
-        }
-
-        handler.handle(isInStructure &&
-                (isAdmin
-                || isTeacherWhomClassBelong));
+        String idStructure = WorkflowActionUtils.getParamStructure(request);
+        boolean isTeacher = user.getType().equals(Field.TEACHER);
+        handler.handle(idStructure != null  && user.getStructures().contains(idStructure) && (isAdmin || isTeacher));
     }
 }

--- a/src/main/java/fr/openent/competences/security/AdministratorRight.java
+++ b/src/main/java/fr/openent/competences/security/AdministratorRight.java
@@ -36,10 +36,6 @@ public class AdministratorRight implements ResourcesProvider {
         String structureId = WorkflowActionUtils.getParamStructure(resourceRequest);
         boolean allowViesco = WorkflowActionUtils.hasRight(user, WorkflowActions.ADMIN_RIGHT.toString());
         boolean allowCompetences = WorkflowActionUtils.hasRight(user, WorkflowActions.COMPETENCES_ACCESS.toString());
-        if(structureId == null){
-            handler.handle(false);
-        } else {
-            handler.handle( user.getStructures().contains(structureId) && allowViesco && allowCompetences);
-        }
+        handler.handle(  structureId != null && user.getStructures().contains(structureId) && allowViesco && allowCompetences);
     }
 }

--- a/src/main/resources/public/ts/services/structure-options.service.ts
+++ b/src/main/resources/public/ts/services/structure-options.service.ts
@@ -32,7 +32,7 @@ export const structureOptionsService: IStructureOptionsService = {
     },
 
     saveStrustureOptionsIsAverageSkills: async(options: StructureOptions): Promise<AxiosResponse> =>{
-        return http.post(`competences/structure/options/isSkillAverage`, options);
+        return http.post(`competences/structure/options/isSkillAverage?structureId=${options.structureId}`, options);
     },
 
     /**

--- a/src/test/java/fr/openent/competences/security/AccessStructureAdminTeacherFilterTest.java
+++ b/src/test/java/fr/openent/competences/security/AccessStructureAdminTeacherFilterTest.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RunWith(VertxUnitRunner.class)
-public class AccessStructureAndAdminOrTeacherCourseFilterTest {
-    AccessStructureAndAdminOrTeacherCourseFilter access;
+public class AccessStructureAdminTeacherFilterTest {
+    AccessStructureAdminTeacherFilter access;
     HttpServerRequest request;
     Binding binding;
     UserInfos user;
@@ -33,7 +33,7 @@ public class AccessStructureAndAdminOrTeacherCourseFilterTest {
 
     @Before
     public void setUp(){
-        access = new AccessStructureAndAdminOrTeacherCourseFilter();
+        access = new AccessStructureAdminTeacherFilter();
         request = Mockito.mock(HttpServerRequest.class);
         binding = Mockito.mock(Binding.class);
         user = new UserInfos();

--- a/src/test/java/fr/openent/competences/security/AccessStructureAndAdminOrTeacherCourseFilterTest.java
+++ b/src/test/java/fr/openent/competences/security/AccessStructureAndAdminOrTeacherCourseFilterTest.java
@@ -7,6 +7,7 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.impl.HeadersAdaptor;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.entcore.common.user.UserInfos;
@@ -28,7 +29,7 @@ public class AccessStructureAndAdminOrTeacherCourseFilterTest {
     UserInfos.Action role1;
     List<String> groupsId;
     MultiMap params;
-    List structures;
+    ArrayList<String> structures;
 
     @Before
     public void setUp(){
@@ -44,76 +45,117 @@ public class AccessStructureAndAdminOrTeacherCourseFilterTest {
     }
 
     @Test
-    public void testAuthorizeWrongStructure(TestContext ctx){
+    public void testAuthorize(TestContext ctx) {
+        user.setType(Field.TEACHER);
         role1.setDisplayName(WorkflowActions.ADMIN_RIGHT.toString());
         actions.add(role1);
         user.setAuthorizedActions(actions);
-        params.set(Field.IDETABLISSEMENT,"111111");
-        Mockito.doReturn(params).when(request).params();
-        structures.add("0000000");
+        String structureId = "11111";
+        structures.add(structureId);
         user.setStructures(structures);
-        access.authorize(request,binding,user,result -> {
-            ctx.assertEquals(false,result);
+        params.set("structureId", "11111");
+        Mockito.doReturn(params).when(request).params();
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(true, result);
+            async.complete();
         });
+        async.awaitSuccess(10000);
+    }
+
+
+    @Test
+    public void testBadRightButTeacher(TestContext ctx) {
+        user.setType(Field.TEACHER);
+        role1.setDisplayName(WorkflowActions.COMPETENCES_ACCESS.toString());
+        actions.add(role1);
+        user.setAuthorizedActions(actions);
+        String structureId = "11111";
+        structures.add(structureId);
+        user.setStructures(structures);
+        params.set("structureId", "11111");
+        Mockito.doReturn(params).when(request).params();
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(true, result);
+            async.complete();
+        });
+        async.awaitSuccess(10000);
     }
 
     @Test
-    public void testAuthorizeStructureAdmin(TestContext ctx){
+    public void testBadTypeButAdmin(TestContext ctx) {
+        user.setType("random");
         role1.setDisplayName(WorkflowActions.ADMIN_RIGHT.toString());
         actions.add(role1);
         user.setAuthorizedActions(actions);
-        params.set(Field.IDETABLISSEMENT,"111111");
-        Mockito.doReturn(params).when(request).params();
-        structures.add("111111");
+        String structureId = "11111";
+        structures.add(structureId);
         user.setStructures(structures);
-        access.authorize(request,binding,user,result -> {
-            ctx.assertEquals(true,result);
+        params.set("structureId", "11111");
+        Mockito.doReturn(params).when(request).params();
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(true, result);
+            async.complete();
         });
+        async.awaitSuccess(10000);
     }
 
     @Test
-    public void testAuthorizeStructureTeacherWithClass(TestContext ctx){
+    public void testBadTypeBadRight(TestContext ctx) {
+        user.setType("random");
+        role1.setDisplayName(WorkflowActions.COMPETENCES_ACCESS.toString());
+        actions.add(role1);
         user.setAuthorizedActions(actions);
-
-        user.setType(Field.TEACHER);
-        //Set structure
-        params.set(Field.IDETABLISSEMENT,"111111");
-        structures.add("111111");
+        String structureId = "11111";
+        structures.add(structureId);
         user.setStructures(structures);
-        //Set teacher class
-        List<String> classes = new ArrayList<>();
-        classes.add("000");
-        user.setClasses(classes);
-        params.set(Field.IDCLASSE,"000");
-
-
+        params.set("structureId", "11111");
         Mockito.doReturn(params).when(request).params();
-
-        access.authorize(request,binding,user,result -> {
-            ctx.assertEquals(true,result);
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(false, result);
+            async.complete();
         });
+        async.awaitSuccess(10000);
     }
+
     @Test
-    public void testAuthorizeStructureTeacherWrongClass(TestContext ctx){
+    public void testBadStructureBadType(TestContext ctx) {
+        user.setType("random");
+        role1.setDisplayName(WorkflowActions.ADMIN_RIGHT.toString());
+        actions.add(role1);
         user.setAuthorizedActions(actions);
-
-        user.setType(Field.TEACHER);
-        //Set structure
-        params.set(Field.IDETABLISSEMENT,"111111");
-        structures.add("111111");
+        String structureId = "aaaaa";
+        structures.add(structureId);
         user.setStructures(structures);
-        //Set teacher class
-        List<String> classes = new ArrayList<>();
-        classes.add("000");
-        user.setClasses(classes);
-        params.set(Field.IDCLASSE,"222");
-        //Set teacher Groups
-        user.setGroupsIds(groupsId);
-
+        params.set("structureId", "11111");
         Mockito.doReturn(params).when(request).params();
-
-        access.authorize(request,binding,user,result -> {
-            ctx.assertEquals(false,result);
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(false, result);
+            async.complete();
         });
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testBadStructureBadRight(TestContext ctx) {
+        user.setType(Field.TEACHER);
+        role1.setDisplayName(WorkflowActions.COMPETENCES_ACCESS.toString());
+        actions.add(role1);
+        user.setAuthorizedActions(actions);
+        String structureId = "aaaaa";
+        structures.add(structureId);
+        user.setStructures(structures);
+        params.set("structureId", "11111");
+        Mockito.doReturn(params).when(request).params();
+        Async async = ctx.async();
+        access.authorize(request, binding, user, result -> {
+            ctx.assertEquals(false, result);
+            async.complete();
+        });
+        async.awaitSuccess(10000);
     }
 }


### PR DESCRIPTION
## Describe your changes
After tests made up on NG2 dev-security branch, i had to modify AccessStructureAndAdminOrTeacherCourseFilter to remove checkouts on teacher's classroom.
Moreover, i had to debug the route post /structure/options/isSkillAverage because no structureId was passed in the front API route despite the fact that there is a checkout on the structure in the resource filter.
## Checklist tests
In "viescolaire", competences thumnail and "Niveau de maitrise et calcul du niveau", click on the switch button to ensure you have the rights to compute skill levels.
## Issue ticket number and link
[#EVAL-489](https://jira.support-ent.fr/browse/EVAL-489)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

