### PR TITLE
fix(class-report) #EVAL-498 fix skills line to always take full width and default colors.

### DIFF
--- a/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
+++ b/src/main/resources/public/template/pdf/releve-classe.pdf.xhtml
@@ -104,6 +104,25 @@
             background-color: #f0f0f0;
         }
 
+        .white {
+            background-color: #FFFFFF;
+        }
+        .grey {
+            background-color: #555555;
+        }
+        .red {
+            background-color: #E13A3A;
+        }
+        .orange {
+            background-color: #FD8401;
+        }
+        .yellow {
+            background-color: #ECBE30;
+        }
+        .green {
+            background-color: #46BFAF;
+        }
+
         .upper {
             text-transform: uppercase;
         }
@@ -297,12 +316,12 @@
         {{#showSkills}}
         {{#hasCompetencesNotes}}
         <tr>
-            <td class="competence align-left border-right width-100">
+            <td class="competence align-left border-right width-100" colspan="3">
                 <div>Bilan des items</div>
                 <div class="table width-100">
                     <div class="bars-skills-evaluation width-90">
                         {{# competencesNotes }}
-                        <div class="bar-skill-piece"
+                        <div class="bar-skill-piece {{ color }}"
                              style="width: {{width}}%; background-color: {{ persoColor }} !important">{{ number }}
                         </div>
                         {{/ competencesNotes }}
@@ -440,7 +459,7 @@
                 <div class="table width-100">
                     <div class="bars-skills-evaluation width-90">
                         {{# competencesNotes }}
-                        <div class="bar-skill-piece"
+                        <div class="bar-skill-piece {{ color }}"
                              style="width: {{width}}%; background-color: {{ persoColor }} !important">{{ number }}
                         </div>
                         {{/ competencesNotes }}


### PR DESCRIPTION
## Describe your changes
Dans le PDF du suivi de classe, utilisation de la couleur par défaut quand la couleur personnalisée n'est pas définie.
Ajustement de la case "Bilan des items" pour qu'elle prenne systématiquement toute la longueur.

## Checklist tests
- Sur le suivie d'une classe, télécharger le bilan des notes (notes + compétences) au format PDF.
- Vérifie les réparations.

## Issue ticket number and link
[Jira - EVAL-498](https://jira.support-ent.fr/browse/EVAL-498)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

