### PR TITLE
fix(evaluation): #EVAL-467 waiting evaluations synchronisation before ending init script.

### DIFF
--- a/src/main/resources/public/ts/models/teacher/Structure.ts
+++ b/src/main/resources/public/ts/models/teacher/Structure.ts
@@ -383,6 +383,7 @@ export class Structure extends Model {
                     this.synchronized.annotations &&
                     this.synchronized.niveauCompetences &&
                     this.synchronized.typePeriodes &&
+                    this.synchronized.devoirs &&
                     this.synchronized.detailsUser;
                 if (Utils.isChefEtabOrHeadTeacher()) {
                     b = b && this.synchronized.enseignants;


### PR DESCRIPTION
## Describe your changes
Ajout du paramètre "synchronized.devoirs" requis dans la méthode sync du modèle Structure.ts permettant d'attendre que a récupération des devoirs soit bien faite avant de passer à la suites de l'initialisation des données relatives à la page d'accueil de competences.

Afin de reproduire le bug initialement observé en preprod, il à fallu entourer l'appel de l'enpoint de la récupération des devoirs d'un setTimeout, afin de simuler la lenteur de la récupération. Celà a permis de bien reproduire ce problème en local.

## Issue ticket number and link
[Jira - EVAL-467](https://jira.support-ent.fr/browse/EVAL-467)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

