### PR TITLE
fix(periodicStatement) #fix EVAL-528 calculte student's average only with the evaluation type

### DIFF
--- a/src/main/resources/public/ts/models/teacher/Eleve.ts
+++ b/src/main/resources/public/ts/models/teacher/Eleve.ts
@@ -17,7 +17,7 @@
 
 import {Model, Collection, _, notify, http as httpCore, moment, skin} from 'entcore';
 import http  from 'axios';
-import { Evaluation, SuiviCompetence } from './index';
+import {Devoirs, Evaluation, SuiviCompetence} from './index';
 import {ElementBilanPeriodique} from "./ElementBilanPeriodique";
 import {ExportBulletins} from "../common/ExportBulletins";
 import {DefaultEleve} from "../common/DefaultEleve";
@@ -64,7 +64,8 @@ export class Eleve extends DefaultEleve  {
         return new Promise((resolve, reject) => {
             if (devoirs) {
                 let idDevoirsURL:string = "";
-                _.each(_.pluck(devoirs,'id'), (id) => {
+                let filteredEvaluations : Devoirs = devoirs.filter ( (devoir) => { return !devoir.formative});
+                _.each(_.pluck(filteredEvaluations,'id'), (id) => {
                     idDevoirsURL += "devoirs=" + id + "&";
                 });
                 idDevoirsURL = idDevoirsURL.slice(0, idDevoirsURL.length - 1);


### PR DESCRIPTION

## Describe your changes
filtre sur les devoirs envoyés au back pour le calcul de la moyenne de l'élève. Fix de la précédente PR https://github.com/OPEN-ENT-NG/competences/pull/234
## Checklist tests
relevé périodique au moins deux devoirs (type évaluation et 1 formative). Modifier la une note sur l'évation non formative, la moyenne de l'élève est recalculer seulement avec les notes des devoirs de type évaluation.
## Issue ticket number and link
[EVAL-528](https://jira.support-ent.fr/browse/EVAL-528)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

