### PR TITLE
fix(class tracking) EVAL-531 fix getting teachers appreciations annually.

### DIFF
--- a/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
+++ b/src/main/java/fr/openent/competences/controllers/ExportPDFController.java
@@ -626,7 +626,7 @@ public class ExportPDFController extends ControllerHelper {
 
         Promise<JsonArray> multiTeachingPromise = Promise.promise();
         utilsService.getMultiTeachers(idEtablissement,
-                new JsonArray().add(idClasse), idPeriode.intValue(), FutureHelper.handlerJsonArray(multiTeachingPromise.future()));
+                new JsonArray().add(idClasse), idPeriode, FutureHelper.handlerJsonArray(multiTeachingPromise.future()));
 
         Promise<JsonArray> servicesPromise = Promise.promise();
         utilsService.getServices(idEtablissement,


### PR DESCRIPTION
## Describe your changes
Désormais, sur la page du suivi de classe, la récupération des appréciations des professeurs  sur une période annuel (donc sans filtrer de période) fonctionne.

## Checklist tests
- En tant que personnel, aller sur la page "Suivi classe" => "Appréciations professeurs"
- filtrer avec un group et avec la période "année"
- la page ne génère plus une 500, et fonctionne.

## Issue ticket number and link
[Jira - EVAL-531](https://jira.support-ent.fr/browse/EVAL-531)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

