### PR TITLE
fix(report-export) EVAL-530 handle the case where more than two responsible use the same address

### DIFF
--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -351,6 +351,19 @@ public class Field {
     public static final String SQLPERSISTORADMIN = "sql.persistor.admin";
     public static final String SQLAPPS = "apps";
 
+    // Responsible
+    public static final String ZIPCODE = "zipCode";
+    public static final String ZIPCODE_LOWER_CASE = "zipcode";
+    public static final String CITY = "city";
+    public static final String ADDRESS = "address";
+    public static final String CIVILITE = "civilite";
+
+    public static final String ADDRESSEPOSTALE = "addressePostale";
+    public static final String RESPONSABLELASTNAME = "responsableLastName";
+    public static final String LASTNAMERELATIVE = "lastNameRelative";
+    public static final String FIRSTNAMERELATIVE = "firstNameRelative";
+    public static final String RESPONSABLELIBELLE = "responsableLibelle";
+
 
     //numbers
     public static final double ROUNDER = 10.0; //Cette constante permet d'arrondir au dixième près avec la formule mathémathique adéquate.

--- a/src/test/java/fr/openent/competences/service/impl/DefaultExportBulletinServiceTest.java
+++ b/src/test/java/fr/openent/competences/service/impl/DefaultExportBulletinServiceTest.java
@@ -1,0 +1,126 @@
+package fr.openent.competences.service.impl;
+
+import fr.openent.competences.constants.Field;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DefaultExportBulletinService.class})
+public class DefaultExportBulletinServiceTest {
+
+    private JsonObject matchingResponsibleName = new JsonObject()
+            .put(Field.ADDRESS, "123 Street")
+            .put(Field.ZIPCODE, "12345")
+            .put(Field.CITY, "City1")
+            .put(Field.LASTNAMERELATIVE, "LastName");
+
+    private JsonObject unmatchingResponsibleName = new JsonObject()
+            .put(Field.ADDRESS, "123 Street")
+            .put(Field.ZIPCODE, "12345")
+            .put(Field.CITY, "City1")
+            .put(Field.LASTNAMERELATIVE, "LastName1");
+    private JsonObject unmatchingResponsibleName2 = new JsonObject()
+            .put(Field.ADDRESS, "123 Street")
+            .put(Field.ZIPCODE, "12345")
+            .put(Field.CITY, "City1")
+            .put(Field.LASTNAMERELATIVE, "LastName2");
+
+    private JsonObject unmatchingResponsibleAddress = new JsonObject()
+            .put(Field.ADDRESS, "122 Street")
+            .put(Field.ZIPCODE, "12345")
+            .put(Field.CITY, "City1")
+            .put(Field.LASTNAMERELATIVE, "LastName1");
+
+    @InjectMocks
+    private DefaultExportBulletinService exportBulletinService;
+
+    @Test
+    public void testAreResponsiblesWithAndWithoutCoupleNames_ThirdNoMatchingLastName() throws Exception {
+        JsonObject referentResponsible = new JsonObject()
+                .put(Field.ADDRESSEPOSTALE, String.format("%s %s %s", matchingResponsibleName.getString(Field.ADDRESS),
+                        matchingResponsibleName.getString(Field.ZIPCODE),
+                        matchingResponsibleName.getString(Field.CITY)))
+                .put(Field.RESPONSABLELASTNAME, matchingResponsibleName.getValue(Field.LASTNAMERELATIVE));
+
+        JsonArray responsibles = new JsonArray()
+                .add(matchingResponsibleName)
+                .add(matchingResponsibleName)
+                .add(unmatchingResponsibleName);
+
+        boolean result = Whitebox.invokeMethod(exportBulletinService, "areResponsiblesWithAndWithoutCoupleNames",
+                referentResponsible,
+                responsibles);
+
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testAreResponsiblesWithAndWithoutCoupleNames_twoResponsiblesMatchingLastName() throws Exception {
+        JsonObject referentResponsible = new JsonObject()
+                .put(Field.ADDRESSEPOSTALE, String.format("%s %s %s", matchingResponsibleName.getString(Field.ADDRESS),
+                        matchingResponsibleName.getString(Field.ZIPCODE),
+                        matchingResponsibleName.getString(Field.CITY)))
+                .put(Field.RESPONSABLELASTNAME, matchingResponsibleName.getValue(Field.LASTNAMERELATIVE));
+
+        JsonArray responsibles = new JsonArray()
+                .add(matchingResponsibleName)
+                .add(matchingResponsibleName);
+
+
+
+        boolean result = Whitebox.invokeMethod(exportBulletinService, "areResponsiblesWithAndWithoutCoupleNames",
+                referentResponsible,
+                responsibles);
+
+        Assert.assertFalse(result);
+    }
+    @Test
+    public void testAreResponsiblesWithAndWithoutCoupleNames_twoResponsiblesNoMatchingAddress() throws Exception {
+        JsonObject referentResponsible = new JsonObject()
+                .put(Field.ADDRESSEPOSTALE, String.format("%s %s %s", matchingResponsibleName.getString(Field.ADDRESS),
+                        matchingResponsibleName.getString(Field.ZIPCODE),
+                        matchingResponsibleName.getString(Field.CITY)))
+                .put(Field.RESPONSABLELASTNAME, matchingResponsibleName.getValue(Field.LASTNAMERELATIVE));
+
+        JsonArray responsibles = new JsonArray()
+                .add(matchingResponsibleName)
+                .add(unmatchingResponsibleAddress);
+
+
+
+        boolean result = Whitebox.invokeMethod(exportBulletinService, "areResponsiblesWithAndWithoutCoupleNames",
+                referentResponsible,
+                responsibles);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testAreResponsiblesWithAndWithoutCoupleNames_twoResponsiblesNoMatchingName() throws Exception {
+        JsonObject referentResponsible = new JsonObject()
+                .put(Field.ADDRESSEPOSTALE, String.format("%s %s %s", matchingResponsibleName.getString(Field.ADDRESS),
+                        matchingResponsibleName.getString(Field.ZIPCODE),
+                        matchingResponsibleName.getString(Field.CITY)))
+                .put(Field.RESPONSABLELASTNAME, matchingResponsibleName.getValue(Field.LASTNAMERELATIVE));
+
+        JsonArray responsibles = new JsonArray()
+                .add(matchingResponsibleName)
+                .add(unmatchingResponsibleName);
+
+
+
+        boolean result = Whitebox.invokeMethod(exportBulletinService, "areResponsiblesWithAndWithoutCoupleNames",
+                referentResponsible,
+                responsibles);
+
+        Assert.assertFalse(result);
+    }
+}


### PR DESCRIPTION
## Describe your changes
Lors de l'export de bulletin, lorsqu'un élève avait 3 responsables utilisant la même adresse, on générait une erreur dans le code.
Traite désormais le cas dans lequel il y plus de 2 responsable avec la même adresse pour un étudiant.

## Checklist tests
- Dans la console admin, s'assurer qu'un élève a au moins 3 responsables avec la même adresse.
- Retourner dans compétence , sur l'onglet Générer les bulletins.
- tester l'export d'un bulletin pour l'élève en question. -> c'est ok.

## Issue ticket number and link
[Jira - EVAL-530](https://jira.support-ent.fr/browse/EVAL-530)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

