### PR TITLE
fix(student tracking) EVAL-565 show student names in select when we retrieve them from groups

### DIFF
--- a/src/main/resources/public/template/enseignants/suivi_eleve/left_side.html
+++ b/src/main/resources/public/template/enseignants/suivi_eleve/left_side.html
@@ -54,7 +54,7 @@
                 <option disable value="" class="header-opt leftside">[[translate('viescolaire.utils.student')]]</option>
                 <option class="leftside" ng-repeat ="eleve in filteredEleves.all track by eleve.id"
                     ng-class="{'deletedStudent': !!eleve.deleteDate}"
-                    ng-value = "eleve" >[[eleve.displayName]]</option>
+                    ng-value = "eleve" >[[!!eleve.displayName ? eleve.displayName : (eleve.lastName + ' ' + eleve.firstName)]]</option>
             </select>
         </label>
     </section>


### PR DESCRIPTION
## Describe your changes
Regression dû à cette PR: https://github.com/OPEN-ENT-NG/competences/pull/249
Lors de la sélection d'un groupe dans le suivi d'élève, le nom des étudiants dans le select suivant n'était plus affiché.
Correction de ce cas.

## Checklist tests
- Dans le suivi d'élève
- Sélectionner un groupe (pas une classe)
- vérifier dans le select des élève qu'ils sont bien affichés.

## Issue ticket number and link

[Jira - EVAL-565](https://jira.support-ent.fr/browse/EVAL-565)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

