### PR TITLE
fix: #EVAL-566 get manual student

### DIFF
--- a/src/main/java/fr/openent/competences/service/impl/DefaultUtilsService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultUtilsService.java
@@ -375,10 +375,10 @@ public class DefaultUtilsService implements UtilsService {
         StringBuilder query = new StringBuilder();
         //query.append("MATCH (m:`User` {id: {id}})-[:COMMUNIQUE_DIRECT]->(n:`User`) RETURN n");
 
-        query.append("MATCH (m:`User`{id: {id}})<-[:RELATED]-(n:`User`)-[:ADMINISTRATIVE_ATTACHMENT]->(s:`Structure`) ")
+        query.append("MATCH (m:`User`{id: {id}})<-[:RELATED]-(n:`User`)-[:IN]->(g:ProfileGroup)-[:DEPENDS]->(s:`Structure`) ")
                 .append("WITH n.id as id, n.displayName as displayName, n.classes as externalIdClasse, s.id as idStructure,  ")
-                .append("n.firstName as firstName, n.lastName as lastName MATCH(c:Class)WHERE c.externalId IN externalIdClasse")
-                .append(" RETURN id, displayName, firstName, lastName, c.id as idClasse, idStructure");
+                .append("n.firstName as firstName, n.lastName as lastName MATCH(c:Class) WHERE c.externalId IN externalIdClasse")
+                .append(" RETURN distinct id, displayName, firstName, lastName, c.id as idClasse, idStructure");
         neo4j.execute(query.toString(), new JsonObject().put("id", id), Neo4jResult.validResultHandler(handler));
     }
 

--- a/src/test/java/fr/openent/competences/service/impl/DefaultUtilsServiceTest.java
+++ b/src/test/java/fr/openent/competences/service/impl/DefaultUtilsServiceTest.java
@@ -1,0 +1,65 @@
+package fr.openent.competences.service.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.neo4j.Neo4jRest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Neo4j.class, DefaultUtilsService.class})
+public class DefaultUtilsServiceTest {
+
+    private static final String USER_ID = "111";
+    private final Neo4j neo4j = Neo4j.getInstance();
+
+   @Mock
+    private Neo4jRest neo4jRest;
+
+   @InjectMocks
+   private DefaultUtilsService utilsService;
+
+    @Before
+    public void setUp() throws NoSuchFieldException {
+        FieldSetter.setField(neo4j, neo4j.getClass().getDeclaredField("database"), neo4jRest);
+    }
+
+    @Test
+    public void getMyChildreen() throws Exception{
+
+        StringBuilder queryTest = new StringBuilder();
+        queryTest.append("MATCH (m:`User`{id: {id}})<-[:RELATED]-(n:`User`)-[:IN]->(g:ProfileGroup)-[:DEPENDS]->(s:`Structure`) ")
+                .append("WITH n.id as id, n.displayName as displayName, n.classes as externalIdClasse, s.id as idStructure,  ")
+                .append("n.firstName as firstName, n.lastName as lastName MATCH(c:Class) WHERE c.externalId IN externalIdClasse")
+                .append(" RETURN distinct id, displayName, firstName, lastName, c.id as idClasse, idStructure");
+
+
+        JsonObject expectedParams = new JsonObject()
+                .put("id",USER_ID);
+
+        Mockito.doAnswer((Answer<Void>) invocation -> {
+            String queryResult = invocation.getArgument(0);
+            JsonObject paramsResult = invocation.getArgument(1);
+            assertEquals(queryResult.trim().replaceAll("\\s+", " "),
+                    queryTest.toString().trim().replaceAll("\\s+", " "));
+            assertEquals(expectedParams, paramsResult);
+            return null;
+
+        }).when(neo4jRest).execute(Mockito.anyString(),Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+        this.utilsService.getEnfants(USER_ID, null);
+
+    }
+
+}


### PR DESCRIPTION
## Describe your changes
get student via the profilGroup - Structure and not via the ADMINISTRATIVE_ATTACHMENT relationship betwwen it and the structure
## Checklist tests
Creat manual student. Linked a parent. Connect with this parent : the child must be there.
## Issue ticket number and link
[EVAL-566](https://jira.support-ent.fr/browse/EVAL-566)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

