### PR TITLE
fix(transition) #EVAL-567: calculate skill average in transition is no more by periods

### DIFF
--- a/src/main/java/fr/openent/competences/service/impl/DefaultTransitionService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultTransitionService.java
@@ -395,7 +395,7 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
                 JsonArray valuesMaxCompetence = new fr.wseduc.webutils.collections.JsonArray();
 
                 String queryMaxOrAvgCompNoteNiveauFinalByPeriode = "(SELECT competences_notes.id_competence, " +
-                        "competences_notes.id_eleve, devoirs.id_periode, devoirs.id_matiere, CASE " +
+                        "competences_notes.id_eleve, devoirs.id_matiere, CASE " +
 
                         "WHEN competence_niveau_final.id_eleve IS NULL AND competence_niveau_final_annuel.id_eleve IS NULL" +
                         "   THEN ";
@@ -408,7 +408,7 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
 
                         "ELSE MAX(competence_niveau_final_annuel.niveau_final) " +
 
-                        "END AS comp_note_by_subject_period " +
+                        "END AS comp_note_by_subject " +
                         "FROM " + Competences.COMPETENCES_SCHEMA + ".competences_notes " +
                         "INNER JOIN " + Competences.COMPETENCES_SCHEMA + ".devoirs ON devoirs.id = competences_notes.id_devoir " +
 
@@ -426,11 +426,11 @@ public class DefaultTransitionService extends SqlCrudService implements Transiti
                         "WHERE competences_notes.owner != '" + _id_user_transition_annee +
                         "' AND competences_notes.id_eleve IN " + Sql.listPrepared(vListEleves.toArray()) +
                         "GROUP BY competences_notes.id_competence, competences_notes.id_eleve, competence_niveau_final.id_eleve," +
-                        "competence_niveau_final_annuel.id_eleve, devoirs.id_periode, devoirs.id_matiere)";
+                        "competence_niveau_final_annuel.id_eleve, devoirs.id_matiere)";
 
                 String queryMaxOrAvgCompNoteMat = "(SELECT id_competence, ";
-                queryMaxOrAvgCompNoteMat += (Boolean.TRUE.equals(isSkillAverage)) ? "ROUND(AVG(comp_note_by_subject_period), 2) " :
-                        "MAX(comp_note_by_subject_period) ";
+                queryMaxOrAvgCompNoteMat += (Boolean.TRUE.equals(isSkillAverage)) ? "ROUND(AVG(comp_note_by_subject), 2) " :
+                        "MAX(comp_note_by_subject) ";
                 queryMaxOrAvgCompNoteMat += "AS comp_note_by_subject, id_eleve, id_matiere FROM " + queryMaxOrAvgCompNoteNiveauFinalByPeriode +
                         " AS max_or_avg_mat GROUP BY id_competence, id_eleve, id_matiere)";
 


### PR DESCRIPTION
## Describe your changes
Désormais au calcul de la moyenne des compétences lors de la transition d'année, le calcul ne se plus par période, mais dans sa globalité.

## Checklist tests
- Créer le cas sur un élève dans lequel sur une même compétence:
  - trimestre 2: Il obtient 2 notes à 3 
  - trimestre 3: Il obtient 1 note à 2 
- Refaire le flow de transition
- après cette transition => vérifier que sa moyenne de compétence (dans la vue cycle) est de 3 (et non plus comme avant de 2).

## Issue ticket number and link
[Jira - EVAL-567](https://jira.support-ent.fr/browse/EVAL-567)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

