### PR TITLE
fix(student-tracking) #EVAL-428: show substitute teacher in pdf export only if not deleted

### DIFF
--- a/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultExportService.java
@@ -2242,17 +2242,19 @@ public class DefaultExportService implements ExportService {
                             .collect(Collectors.toList()));
 
                     for(int j = 0; j < multiTeachersMatiere.size(); j ++) {
-                        String coTeacherId = multiTeachersMatiere.getJsonObject(j).getString("second_teacher_id");
+                        if (multiTeachersMatiere.getJsonObject(j).getString(Field.DELETED_DATE) == null) {
+                            String coTeacherId = multiTeachersMatiere.getJsonObject(j).getString(Field.SECOND_TEACHER_ID);
 
-                        JsonObject coTeacher = (JsonObject) users.stream()
-                                .filter(el -> coTeacherId.equals(((JsonObject) el).getString("id")))
-                                .findFirst().orElse(null);
+                            JsonObject coTeacher = (JsonObject) users.stream()
+                                    .filter(el -> coTeacherId.equals(((JsonObject) el).getString(Field.ID)))
+                                    .findFirst().orElse(null);
 
-                        if(coTeacher != null) {
-                            String multiTeacherName = coTeacher.getString("firstName").charAt(0) + "." +
-                                    coTeacher.getString("name");
-                            if(!_enseignantMatiere.contains(multiTeacherName)) {
-                                _enseignantMatiere.add(multiTeacherName);
+                            if(coTeacher != null) {
+                                String multiTeacherName = coTeacher.getString(Field.FIRSTNAME).charAt(0) + "." +
+                                        coTeacher.getString(Field.NAME);
+                                if(!_enseignantMatiere.contains(multiTeacherName)) {
+                                    _enseignantMatiere.add(multiTeacherName);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Describe your changes
Désormais sur une matière, si un coenseignant à été supprimé, il n'est plus affiché.

## Checklist tests
- Suivi élève -> suivi des notes export de pdf
- Ajouter dans un premier temps un coenseignant
- Il est affiché à l'export du PDF
- Supprimer ce coenseignant
- Il n'est plus affiché à l'export du PDF

## Issue ticket number and link
[Jira - EVAL-428](https://jira.support-ent.fr/browse/EVAL-428)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)



