### PR TITLE
fix(student-tracking) #EVAL-542: round the average up to one decimal when necessary

### DIFF
--- a/src/main/java/fr/openent/competences/service/impl/DefaultUtilsService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultUtilsService.java
@@ -441,15 +441,13 @@ public class DefaultUtilsService implements UtilsService {
         DecimalFormatSymbols symbols = new DecimalFormatSymbols(new Locale("fr", "FR"));
         symbols.setDecimalSeparator('.');
 
-        DecimalFormat df = new DecimalFormat("#.0", symbols);
-        df.setRoundingMode(RoundingMode.HALF_UP);//with this mode 2.125 -> 2.13 without 2.125 -> 2.12
-
+        double precision = 1e1;
         try {
             if (moyenne.isNaN()) {
                 moyenne = null;
             } else {
                 if (!annual)
-                    moyenne = Double.valueOf(df.format(moyenne));
+                    moyenne = Double.valueOf(Math.round(moyenne * precision) / precision);
             }
 
         } catch (NumberFormatException e) {

--- a/src/main/resources/public/ts/utils/functions/average.ts
+++ b/src/main/resources/public/ts/utils/functions/average.ts
@@ -73,7 +73,8 @@ function getMoyenne(devoirs): number | string {
 
             if (null == moyenne) moyenne = 0.0;
 
-            return +(moyenne).toFixed(1);
+            const precision: number = 1;
+            return (+(Math.round(+(moyenne + 'e' + precision)) + 'e' + -precision)).toFixed(precision);
         } else {
             return "NN";
         }


### PR DESCRIPTION
## Describe your changes
- Initialement une moyenne à 12.85 est arrondi à 12.8 (inférieur) alors que ce qui est souhaité ici, c'est arrondi à la moyenne supérieur 12.9.
- Même problème à l'export PDF.

## Checklist tests
- Avoir un élève ayant une moyenne non arrondit à 12.85 (par exemple. Un note à 13 et une autre à 12.7 sur une matière).
- Suivi élève -> SUIVI DES NOTES
- La moyenne pour la matière sélectionnée doit être à 12.85 (en suivant l'exemple précédent)
- Idem sur l'export PDF.

## Issue ticket number and link
[Jira - EVAL-542](https://jira.support-ent.fr/browse/EVAL-542)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

