### PR TITLE
fix(class-tracking) #EVAL-501: reload data when we go out and come back into the competences by teaching view.

### DIFF
--- a/src/main/resources/public/ts/models/common/DefaultCompetence.ts
+++ b/src/main/resources/public/ts/models/common/DefaultCompetence.ts
@@ -19,6 +19,23 @@ import { Model, Collection } from 'entcore';
 import { Competence } from "../teacher";
 import {Matiere} from "../parent_eleve/Matiere";
 
+export interface ICompetenceResponse {
+    id: number;
+    nom?: string;
+    index?: number;
+    code_domaine?: string;
+    hasnameperso?: boolean;
+    ismanuelle?: boolean;
+    masque?: boolean;
+    competences_2?: ICompetenceResponse[];
+    id_cycle?: number;
+    id_enseignement?: number;
+    id_parent?: number;
+    id_type?: number;
+    ids_domaine?: string;
+    ids_domaine_int?: number[];
+}
+
 export class DefaultCompetence extends Model {
     competences: Collection<Competence>;
     selected: boolean;

--- a/src/main/resources/public/ts/models/common/DefaultEnseignement.ts
+++ b/src/main/resources/public/ts/models/common/DefaultEnseignement.ts
@@ -18,8 +18,16 @@
 import {Model, Collection, _ ,angular} from 'entcore';
 import { Competence } from "../parent_eleve/Competence";
 import { Evaluations} from "../eval_parent_mdl";
-import http from "axios";
+import http, {AxiosResponse} from "axios";
 import {DefaultMatiere} from "./DefaultMatiere";
+import {ICompetenceResponse} from "./DefaultCompetence";
+
+export interface ITeachingResponse {
+    id: number;
+    nom?: string;
+    competences_1?: ICompetenceResponse[];
+    ids_domaine_int?: number[];
+}
 
 export class DefaultEnseignement extends Model {
     id;
@@ -113,27 +121,17 @@ export class DefaultEnseignement extends Model {
         });
     }
 
-    public static async getAll(idClasse: string, idCycle: string, model: any){
-        return new Promise(async (resolve,reject) => {
-            let uri = Evaluations.api.GET_ENSEIGNEMENT;
-            uri += '?idClasse=' + idClasse;
-            if (idCycle !== undefined) {
-                uri += '&idCycle=' + idCycle;
-            }
-            try {
-                if (_.isEmpty(model.all)) {
-                    let res = await http.get(uri);
-                    resolve(res);
-                }
-                else {
-                    resolve({data: model.all});
-                }
-            }
-            catch (e){
-                console.error(e);
-                reject(e);
-            }
-        });
+    public static async getAll(idClasse: string, idCycle: string, model: any): Promise<AxiosResponse<ITeachingResponse[]>> {
+        let cycleFilter: string = !!idCycle ? `&idCycle=${idCycle}` : '';
+        try {
+            return !!model.all && !!model.all.length ?
+                Promise.resolve({data: [...<ITeachingResponse[]>model.all.map(m => m.data)],
+                    status: 200, statusText: "OK", headers: {}, config: {}}) :
+                http.get(`${Evaluations.api.GET_ENSEIGNEMENT}?idClasse=${idClasse}${cycleFilter}`)
+        } catch (err) {
+            console.error(err);
+            throw err;
+        }
     }
     getListObjectMatEnseignement (idsMatiereEns, matieresStructure) : DefaultMatiere[]{
 


### PR DESCRIPTION
## Describe your changes
Initialement, quand on sur le Suivi classe, en mode Vue par enseignements, quand on allait sur une autre vue (POSITIONNEMENTS par exemple) et qu'on revenais sur SUIVI DES ITEMS, plus aucune données ne s'affichaient.
fix ce problème.

## Checklist tests
- Suivi classe -> SUIVI DES ITEMS -> Vue par enseignements
- Les données sont affichés
-  POSITIONNEMENTS -> SUIVI DES ITEMS
- Le données sont toujours affichés

## Issue ticket number and link
[Jira - EVAL-501](https://jira.support-ent.fr/browse/EVAL-501)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

