### PR TITLE
feat(LSU) #EVAL-540: export LSU now nullifies description when empty

### DIFF
--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -131,11 +131,14 @@ public class Field {
     // SUBJECT
     public static final String SUBJECTS = "subjects";
 
+    //LSU
+    public static final String EPI = "EPI";
 
     //variables
     public static final String AVERAGES = "averages";
     public static final String APPRECIATION_MATIERE_PERIODE = "appreciation_matiere_periode";
     public static final String COLOR = "color";
+    public static final String DESCRIPTION = "description";
     public static final String PREVIOUSAPPRECIATIONS = "previousAppreciations";
     public static final String FIRSTNAME = "firstName";
     public static final String FINALAVERAGES = "finalAverages";
@@ -154,6 +157,7 @@ public class Field {
     public static final String COEFFICIENT = "coefficient";
     public static final String GROUPS = "groups";
     public static final String TEACHERS = "teachers";
+    public static final String THEME = "theme";
     public static final String LASTNAME = "lastName";
     public static final String LIMIT = "limit";
     public static final String MATIERE = "matiere";

--- a/src/main/java/fr/openent/competences/controllers/LSUController.java
+++ b/src/main/java/fr/openent/competences/controllers/LSUController.java
@@ -21,6 +21,7 @@ import fr.openent.competences.Competences;
 import fr.openent.competences.Utils;
 import fr.openent.competences.bean.lsun.ElementProgramme;
 import fr.openent.competences.bean.lsun.*;
+import fr.openent.competences.constants.Field;
 import fr.openent.competences.enums.LevelCycle;
 import fr.openent.competences.model.Service;
 import fr.openent.competences.model.SubTopic;
@@ -2188,13 +2189,14 @@ public class LSUController extends ControllerHelper {
                                 && element.getJsonArray("groupes").size() > 0) {
 
                             Epi epi = objectFactory.createEpi();
-                            EpiThematique epiThematique = objectFactory.createEpiThematique();;
+                            EpiThematique epiThematique = objectFactory.createEpiThematique();
                             EpiGroupe epiGroupe = objectFactory.createEpiGroupe();
-                            JsonObject theme = element.getJsonObject("theme");
+                            JsonObject theme = element.getJsonObject(Field.THEME);
 
-                            epi.setId("EPI_" + element.getInteger("id"));
-                            epi.setIntitule(theme.getString("libelle"));
-                            epi.setDescription(element.getString("description"));
+                            String description = element.getString(Field.DESCRIPTION);
+                            epi.setId(String.format("%s_%s", Field.EPI, element.getInteger(Field.ID)));
+                            epi.setIntitule(theme.getString(Field.LIBELLE));
+                            epi.setDescription(description != null && !"".equals(description.trim()) ? description : null);
 
                             if (ThematiqueEpi.contains(theme.getString("code"))) {
                                 epi.setThematique(theme.getString("code"));


### PR DESCRIPTION
## Describe your changes
Initialement, l'export bloquait lorsque la description était vide => "". Un message nous afficher que la description ne matchait pas avec la regex (.|\n)[^\s](.|\n).

## Checklist tests
- Ajouter mon modifier un projet éducatif (viescolaire => competences) en lui donnant cette description => &lt;script&gt;alert("XSS");&lt;/script&gt;
La chaine de caractère n'étant pas compatible avec la regex, le script d'enregistrement va enregistrer une chaine de caractère vide => c'est ce qui provoquait initialement notre problème.
- tester l'export lsu (competences)
- ça fonctionne !

## Issue ticket number and link
[Jira - EVAL-540](https://jira.support-ent.fr/browse/EVAL-540)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

