### PR TITLE
feat(student-view) #EVAL-569: fix showing scores in year view from periodic statement in student account.

### DIFF
--- a/src/main/resources/public/ts/models/eval_parent_mdl.ts
+++ b/src/main/resources/public/ts/models/eval_parent_mdl.ts
@@ -140,7 +140,7 @@ export class Evaluations extends Model {
                             uri += '&idClasse=' + classeId;
                         }
 
-                        if (idPeriode !== undefined) {
+                        if (idPeriode !== null && idPeriode > -1) {
                             uri += '&idPeriode=' + idPeriode;
                         }
 
@@ -200,7 +200,7 @@ export class Evaluations extends Model {
 
                                 // RECUPERATION DES ANNOTATIONS
                                 let uriAnnotations = Evaluations.api.GET_ANNOTATION + '?idEleve=' + userId;
-                                if (idPeriode !== undefined) {
+                                if (idPeriode !== null && idPeriode > -1) {
                                     uriAnnotations += '&idPeriode=' + idPeriode;
                                 }
 

--- a/src/main/resources/public/ts/utils/functions/average.ts
+++ b/src/main/resources/public/ts/utils/functions/average.ts
@@ -217,9 +217,9 @@ export async function calculMoyennesWithSubTopic(periode_idType: number, id_elev
                                                  subTopicsServices: SubtopicserviceService[], classe: Classe): Promise<{}> {
     return new Promise(async (resolve, reject) => {
         try {
-            let url = '/competences/eleve/' + id_eleve + "/moyenneFinale?";
-            if (periode_idType)
-                url += "idPeriode=" + periode_idType.toString();
+            let url = '/competences/eleve/' + id_eleve + "/moyenneFinale";
+            if (periode_idType != null && periode_idType > -1)
+                url += "?idPeriode=" + periode_idType.toString();
             http.get(url).then(res => {
                 let moyennesFinales: IOverrideAverageResponse[] = res.data;
                 setOverrideAverage(matieresReleve, matieres, moyennesFinales);


### PR DESCRIPTION
## Describe your changes
Initialement, sur la vue étudiant, dans le relevé périodique, avec la période sélectionné "Année", aucune notes ne s'affichais (empty state).
Correction de ce problème.

## Checklist tests
- se connecter en tant qu'étudiant
- Aller sur le relevé périodique
- filtrer par année
- les notes / moyennes s'affiches.

## Issue ticket number and link
[Jira - EVAL-569](https://jira.support-ent.fr/browse/EVAL-569)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

