### PR TITLE
feat: #EVAL-664 update average api to add final status

### DIFF
--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -163,6 +163,8 @@ public class Field {
     public static final String NN = "NN";
     public static final String EA = "EA";
     public static final String DI = "DI";
+    public static final String NULL = "null";
+    public static final String NULLFINALE = "nullFinale";
     public static final String SAVE_BFC = "saveBFC";
     public static final String SUBCOEF = "subCoef";
     public static final String SERVICE_SUBTOPIC = "services_subtopic";

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -181,6 +181,8 @@ public class Field {
     public static final String MODULENAME = "moduleName";
     public static final String MOYENNE = "moyenne";
     public static final String MOY = "moy";
+    public static final String MOYENNEFINALE = "moyenneFinale";
+    public static final String MOYENNESFINALE = "moyennesFinale";
     public static final String NOTEMAX = "noteMax";
     public static final String NOTEMIN = "noteMin";
     public static final String UNROUND_AVERAGE = "unround_average";

--- a/src/main/java/fr/openent/competences/constants/Field.java
+++ b/src/main/java/fr/openent/competences/constants/Field.java
@@ -190,6 +190,7 @@ public class Field {
     public static final String MOYGENERALEELEVE = "moyGeneraleEleve";
     public static final String MOYENNE_GENERALE = "moyenne_generale";
     public static final String MOYENNE_FINALE = "moyenne_finale";
+    public static final String MOYENNESCLASSE = "moyennesClasse";
     public static final String MOYENNESFINALES = "moyennesFinales";
     public static final String MOYENNEBYMAT = "moyenneByMat";
     public static final String MOYENNECLASSE = "moyenneClasse";

--- a/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
@@ -545,7 +545,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
                                     ? optMoyenneFinale.get().getMoyenne()
                                     : optMoyenneFinale.get().getStatut();
                             moyenneFinale.put(MOYENNEFINALE, value);
-                            moyenneFinale.put(Field.ID_PERIODE, idPeriod.toString()); // stocké en String pour éviter les erreurs de comparaison
+                            moyenneFinale.put(Field.ID_PERIODE, idPeriod);
 
                             JsonArray moyennesFinales = result.getJsonArray(MOYENNESFINALES, new JsonArray());
 
@@ -568,16 +568,26 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
                                 .put(ID, idPeriod);
 
                         JsonArray moyennes = result.getJsonArray(Field.MOYENNES, new JsonArray());
+                        JsonArray moyennesClasse = result.getJsonArray(Field.MOYENNESCLASSE, new JsonArray());
 
-                        boolean alreadyExists = moyennes.stream()
+                        boolean moyenneAlreadyExists = moyennes.stream()
                                 .map(obj -> (JsonObject) obj)
                                 .anyMatch(m -> idPeriod.toString().equals(m.getString(ID)));
 
-                        if (!alreadyExists) {
+                        if (!moyenneAlreadyExists) {
                             moyennes.add(newMoyenne);
                         }
 
+                        boolean moyenneClasseAlreadyExists = moyennesClasse.stream()
+                                .map(obj -> (JsonObject) obj)
+                                .anyMatch(m -> idPeriod.toString().equals(m.getString(ID)));
+
+                        if (!moyenneClasseAlreadyExists) {
+                            moyennesClasse.add(newMoyenne);
+                        }
+
                         result.put(Field.MOYENNES, moyennes);
+                        result.put(Field.MOYENNESCLASSE, moyennesClasse);
                     });
 
             futures.add(future);

--- a/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
@@ -5,10 +5,9 @@ import fr.openent.competences.Utils;
 import fr.openent.competences.bean.NoteDevoir;
 import fr.openent.competences.constants.Field;
 import fr.openent.competences.enums.EventType;
-import fr.openent.competences.helpers.FutureHelper;
 import fr.openent.competences.message.MessageResponseHandler;
 import fr.openent.competences.model.Service;
-import fr.openent.competences.model.achievements.AchievementsProgress;
+import fr.openent.competences.repository.RepositoryFactory;
 import fr.openent.competences.service.*;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.*;
@@ -17,16 +16,18 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.sql.Sql;
-import org.entcore.common.sql.SqlResult;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static fr.openent.competences.Competences.*;
 import static fr.openent.competences.Utils.isNotNull;
 import static fr.openent.competences.Utils.isNull;
+import static fr.openent.competences.constants.Field.*;
 import static fr.openent.competences.helpers.FormateFutureEvent.formate;
 import static fr.openent.competences.service.impl.DefaultExportBulletinService.TIME;
 import static fr.openent.competences.service.impl.DefaultExportService.COEFFICIENT;
@@ -43,6 +44,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
     private final Sql sql;
     private final MatiereService defautlMatiereService;
     private final StructureOptionsService structureOptionsService;
+    private final UserService userService;
 
 
     public DefaultBilanPerioqueService(Sql sql, EventBus eb) {
@@ -54,6 +56,9 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
         defautlMatiereService = new DefaultMatiereService(eb);
         structureOptionsService = new DefaultStructureOptions(eb);
         this.sql = sql;
+        Neo4j neo4j = Neo4j.getInstance();
+        RepositoryFactory repositoryFactory = new RepositoryFactory(neo4j);
+        this.userService = new DefaultUserService(repositoryFactory);
     }
 
     @Override
@@ -504,15 +509,83 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
 
         Future.all(subjectsFuture).onComplete(event -> {
             if (event.succeeded()) {
-                log.info("niko : " + results);
-                handler.handle(new Either.Right<>(Utils.sortJsonArrayIntValue("rank", results)));
+                transformResults(results, idPeriod, idEleve).onComplete(transformEvent -> {
+                    if (transformEvent.succeeded()) {
+                        handler.handle(new Either.Right<>(Utils.sortJsonArrayIntValue("rank", results)));
+                    } else {
+                        String error = transformEvent.cause().getMessage();
+                        log.error(error);
+                        handler.handle(new Either.Left<>(error));
+                    }
+                });
             } else {
                 String error = event.cause().getMessage();
                 log.error(error);
                 handler.handle(new Either.Left<>(error));
             }
         });
+
     }
+
+    private Future<Void> transformResults(JsonArray results, Long idPeriod, String idEleve) {
+        List<Future> futures = new ArrayList<>();
+
+        for (int i = 0; i < results.size(); i++) {
+            JsonObject result = results.getJsonObject(i);
+
+            if (!result.containsKey(Field.ID_MATIERE)) continue;
+
+            String idMatiere = result.getString(Field.ID_MATIERE);
+
+            Future<Boolean> future = DefaultNoteService.getMoyenneFinaleByIdEleveAndIdMatiereAndIdPeriod(idEleve, idMatiere, idPeriod)
+                    .compose(optMoyenneFinale -> {
+                        if (optMoyenneFinale.isPresent()) {
+                            JsonObject moyenneFinale = new JsonObject();
+                            Object value = optMoyenneFinale.get().getMoyenne() != null
+                                    ? optMoyenneFinale.get().getMoyenne()
+                                    : optMoyenneFinale.get().getStatut();
+                            moyenneFinale.put(MOYENNEFINALE, value);
+                            moyenneFinale.put(Field.ID_PERIODE, idPeriod.toString()); // stocké en String pour éviter les erreurs de comparaison
+
+                            JsonArray moyennesFinales = result.getJsonArray(MOYENNESFINALE, new JsonArray());
+
+                            // Supprimer les doublons avec le même ID_PERIODE
+                            JsonArray filtered = new JsonArray();
+                            for (int j = 0; j < moyennesFinales.size(); j++) {
+                                JsonObject obj = moyennesFinales.getJsonObject(j);
+                                if (!idPeriod.toString().equals(obj.getString(Field.ID_PERIODE))) {
+                                    filtered.add(obj);
+                                }
+                            }
+                            filtered.add(moyenneFinale);
+                            result.put(MOYENNESFINALE, filtered);
+                        }
+                        return userService.isUserInThirdClassLevel(idEleve);
+                    })
+                    .onSuccess(isThirdClassLevel -> {
+                        JsonObject newMoyenne = new JsonObject()
+                                .put(Field.MOYENNE, isThirdClassLevel ? EA : Field.NN)
+                                .put(ID, idPeriod.toString());
+
+                        JsonArray moyennes = result.getJsonArray(Field.MOYENNES, new JsonArray());
+
+                        boolean alreadyExists = moyennes.stream()
+                                .map(obj -> (JsonObject) obj)
+                                .anyMatch(m -> idPeriod.toString().equals(m.getString(ID)));
+
+                        if (!alreadyExists) {
+                            moyennes.add(newMoyenne);
+                        }
+
+                        result.put(Field.MOYENNES, moyennes);
+                    });
+
+            futures.add(future);
+        }
+
+        return CompositeFuture.all(futures).mapEmpty();
+    }
+
 
     private void buildSubjectForSuivi(Map<String, JsonObject> idsMatieresIdsTeachers, JsonArray idsTeachers,
                                       JsonArray subjects, final Long idPeriode,

--- a/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
@@ -375,7 +375,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
     private void setSubjectLibelle(String idMatiere, JsonObject result, Map<String, JsonObject> idsMatLibelle) {
         if (idsMatLibelle != null && !idsMatLibelle.isEmpty() && idsMatLibelle.containsKey(idMatiere)) {
             result.put("id_matiere", idMatiere)
-                    .put("libelleMatiere", idsMatLibelle.get(idMatiere).getString(NAME))
+                    .put("libelleMatiere", idsMatLibelle.get(idMatiere).getString(Field.NAME))
                     .put(SOUS_MATIERES, idsMatLibelle.get(idMatiere).getJsonArray("sous_matieres"))
                     .put("rank", idsMatLibelle.get(idMatiere).getInteger("rank"));
         } else {
@@ -475,7 +475,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
 
             // Récupération du tableau de conversion des compétences notes
             Promise<JsonArray> tableauDeConversionPromise = Promise.promise();
-            new DefaultCompetenceNoteService(COMPETENCES_SCHEMA, COMPETENCES_NOTES_TABLE)
+            new DefaultCompetenceNoteService(COMPETENCES_SCHEMA, Field.COMPETENCES_NOTES_TABLE)
                     .getConversionNoteCompetence(idEtablissement, idClasse,  // note : Est ce que c'est pas l'idGroupeClasse qu'on doit passé ici ?
                             tableauEvent -> formate(tableauDeConversionPromise, tableauEvent));
 
@@ -594,7 +594,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
 
         for (int i = 0; i < subjects.size(); i++) {
             JsonObject subject = subjects.getJsonObject(i);
-            final String idMatiere = subject.getString(ID_MATIERE);
+            final String idMatiere = subject.getString(Field.ID_MATIERE);
             Long id_periode = subject.getLong("id_periode");
             String id_groupe = subject.getString("id_groupe");
 

--- a/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
@@ -547,7 +547,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
                             moyenneFinale.put(MOYENNEFINALE, value);
                             moyenneFinale.put(Field.ID_PERIODE, idPeriod.toString()); // stocké en String pour éviter les erreurs de comparaison
 
-                            JsonArray moyennesFinales = result.getJsonArray(MOYENNESFINALE, new JsonArray());
+                            JsonArray moyennesFinales = result.getJsonArray(MOYENNESFINALES, new JsonArray());
 
                             // Supprimer les doublons avec le même ID_PERIODE
                             JsonArray filtered = new JsonArray();
@@ -558,14 +558,14 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
                                 }
                             }
                             filtered.add(moyenneFinale);
-                            result.put(MOYENNESFINALE, filtered);
+                            result.put(MOYENNESFINALES, filtered);
                         }
                         return userService.isUserInThirdClassLevel(idEleve);
                     })
                     .onSuccess(isThirdClassLevel -> {
                         JsonObject newMoyenne = new JsonObject()
                                 .put(Field.MOYENNE, isThirdClassLevel ? EA : Field.NN)
-                                .put(ID, idPeriod.toString());
+                                .put(ID, idPeriod);
 
                         JsonArray moyennes = result.getJsonArray(Field.MOYENNES, new JsonArray());
 

--- a/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
@@ -510,13 +510,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
         Future.all(subjectsFuture).onComplete(event -> {
             if (event.succeeded()) {
                 transformResults(results, idPeriod, idEleve).onComplete(transformEvent -> {
-                    if (transformEvent.succeeded()) {
-                        handler.handle(new Either.Right<>(Utils.sortJsonArrayIntValue("rank", results)));
-                    } else {
-                        String error = transformEvent.cause().getMessage();
-                        log.error(error);
-                        handler.handle(new Either.Left<>(error));
-                    }
+                    handler.handle(new Either.Right<>(Utils.sortJsonArrayIntValue("rank", results)));
                 });
             } else {
                 String error = event.cause().getMessage();
@@ -588,6 +582,10 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
 
                         result.put(Field.MOYENNES, moyennes);
                         result.put(Field.MOYENNESCLASSE, moyennesClasse);
+                    })
+                    .onFailure(err -> {
+                        String errorMessage = "Failed to transform results";
+                        log.error("[Competences@DefaultBilanPeriodique::transformResults] " + errorMessage + " : " + err.getMessage());
                     });
 
             futures.add(future);

--- a/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultBilanPerioqueService.java
@@ -504,6 +504,7 @@ public class DefaultBilanPerioqueService implements BilanPeriodiqueService {
 
         Future.all(subjectsFuture).onComplete(event -> {
             if (event.succeeded()) {
+                log.info("niko : " + results);
                 handler.handle(new Either.Right<>(Utils.sortJsonArrayIntValue("rank", results)));
             } else {
                 String error = event.cause().getMessage();

--- a/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
@@ -87,6 +87,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
     public static final String COLSPAN = "colspan";
     public static final String MOYSPAN = "moyspan";
     public static final String MOYENNES_CLASSE = "moyennesClasse";
+    public static final String _MOYENNE_CLASSE = "_moyenne_classe";
     public static final String STUDENT_RANK = "studentRank";
     public static final String CLASS_AVERAGE_MINMAX = "classAverageMinMax";
     public static final String NOTES_BY_PERIODE_BY_STUDENT = "notes_by_periode_by_student";
@@ -2864,6 +2865,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                         }
                         addIsThirdClassLevelFieldForEachStudent(elevesMapObject)
                                 .compose(v -> addMoyenneFinale(elevesMapObject, idMatiere, idPeriode))
+                                .compose(v -> transformMoyenneClasse(elevesMapObject, resultHandler))
                                 .compose(v -> addIsMatiereDispensableFieldForEachStudent(elevesMapObject, idMatiere))
                                 .onSuccess(v -> {
                                     handler.handle(new Either.Right<>(resultHandler
@@ -2949,6 +2951,44 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
         }
 
         return CompositeFuture.all(futures).mapEmpty();
+    }
+
+    private Future<Void> transformMoyenneClasse(Map<String, JsonObject> elevesMapObject, JsonObject result) {
+        Promise<Void> promise = Promise.promise();
+
+        String idFirstEleve = elevesMapObject.keySet().stream().findFirst().orElse(null);
+
+        userService.isUserInThirdClassLevel(idFirstEleve)
+                .onSuccess(isInThirdClass -> {
+                    if (isInThirdClass) {
+                        JsonObject moyenneClasseObj = result.getJsonObject(_MOYENNE_CLASSE, new JsonObject());
+                        String[] keys = new String[]{MIN, MAX, Field.MOYENNE};
+
+                        // Remplace "NN" par "EA" dans "null"
+                        JsonObject moyenneClasse = moyenneClasseObj.getJsonObject(NULL, new JsonObject());
+                        for (String key : keys) {
+                            if (Field.NN.equals(moyenneClasse.getString(key))) {
+                                moyenneClasse.put(key, EA);
+                            }
+                        }
+                        moyenneClasseObj.put(NULL, moyenneClasse); // update in parent object
+
+                        // Remplace "NN" par "EA" dans "nullFinale"
+                        JsonObject moyenneFinaleClasse = moyenneClasseObj.getJsonObject(NULLFINALE, new JsonObject());
+                        for (String key : keys) {
+                            if (Field.NN.equals(moyenneFinaleClasse.getString(key))) {
+                                moyenneFinaleClasse.put(key, EA);
+                            }
+                        }
+                        moyenneClasseObj.put(NULLFINALE, moyenneFinaleClasse); // update in parent object
+
+                        // Réinjecte dans le result final (si besoin)
+                        result.put(_MOYENNE_CLASSE, moyenneClasseObj);
+                    }
+                    promise.complete();
+                });
+
+        return promise.future();
     }
 
     public static Future<Optional<MoyenneFinale>> getMoyenneFinaleByIdEleveAndIdMatiereAndIdPeriod(String idEleve, String idMatiere, Long idPeriode) {
@@ -3291,12 +3331,12 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                                 .put("max", statMoyF.getValue("noteMax"))
                                 .put("moyenne", statMoyF.getValue("moyenne"));
                     }
-                    result.put("_moyenne_classe", new JsonObject().put("nullFinal", o_statClasseF));
+                    result.put(_MOYENNE_CLASSE, new JsonObject().put("nullFinal", o_statClasseF));
                     JsonObject o_statClasse = new JsonObject()
                             .put("min", Field.NN)
                             .put("max", Field.NN)
                             .put("moyenne", Field.NN);
-                    result.getJsonObject("_moyenne_classe").put("null", o_statClasse);
+                    result.getJsonObject(_MOYENNE_CLASSE).put("null", o_statClasse);
                 }
             } else {
                 for (Map.Entry<String, JsonObject> student : eleveMapObject.entrySet()) {
@@ -3676,9 +3716,9 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                 moyClasse = (nbMoyenneClasse > 0) ? (sumMoyClasse / nbMoyenneClasse) : " ";
                 result.put("moyenne_classe", moyClasse);
             }
-            result.put("_moyenne_classe", new JsonObject());
+            result.put(_MOYENNE_CLASSE, new JsonObject());
             JsonObject moyClasseObj = new JsonObject().put(Field.MIN, min).put(Field.MAX, max).put(Field.MOYENNE, moyClasse);
-            result.getJsonObject("_moyenne_classe").put("nullFinal", moyClasseObj);
+            result.getJsonObject(_MOYENNE_CLASSE).put("nullFinal", moyClasseObj);
             for (Map.Entry<Long, Double> sousMatMoyClasse : mapSumMoyClasse.entrySet()) {
                 Double moySousMat = sousMatMoyClasse.getValue();
                 Long idSousMat = sousMatMoyClasse.getKey();
@@ -3687,7 +3727,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                 Object moySous = (nbSousMoyClass > 0) ? (moySousMat / nbSousMoyClass) : " ";
                 JsonObject moySousMatCl = new JsonObject().put(MIN, mapMin.get(idSousMat))
                         .put(MAX, mapMax.get(idSousMat)).put(Field.MOYENNE, decimalFormat.format(moySous));
-                result.getJsonObject("_moyenne_classe").put(key, moySousMatCl);
+                result.getJsonObject(_MOYENNE_CLASSE).put(key, moySousMatCl);
             }
 
             HashMap<Long, JsonArray> listMoy = new HashMap<>();
@@ -4963,7 +5003,7 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
             String moyLibelle = getLibelle("average.class") + " " + sousMatiere.getString(Field.LIBELLE);
             Long idSousMatiere = sousMatiere.getLong(ID_SOUS_MATIERE);
             sousMatiere.put("_"+ Field.LIBELLE, moyLibelle);
-            Object moy = result.getJsonObject("_moyenne_classe");
+            Object moy = result.getJsonObject(_MOYENNE_CLASSE);
             if(isNotNull(moy) && isNotNull(idSousMatiere)){
                 moy = ((JsonObject) moy).getJsonObject(idSousMatiere.toString());
                 if(isNotNull(moy)){

--- a/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
+++ b/src/main/java/fr/openent/competences/service/impl/DefaultNoteService.java
@@ -2928,6 +2928,12 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                         } else {
                             student.put(MOYENNEFINALE, student.getValue(Field.MOYENNE));
                         }
+                    })
+                    .recover(err -> {
+                        String errorMessage = "Échec récupération moyenne_finale pour élève "
+                                + studentId + " et matière " + idMatiere + " : " + err.getMessage();
+                        log.error("[Competences@DefaultNoteService::addMoyenneFinale] " + errorMessage);
+                        return Future.succeededFuture(Optional.empty());
                     });
 
             futures.add(future);
@@ -2986,6 +2992,10 @@ public class DefaultNoteService extends SqlCrudService implements NoteService {
                         result.put(_MOYENNE_CLASSE, moyenneClasseObj);
                     }
                     promise.complete();
+                })
+                .onFailure(err -> {
+                    String errorMessage = "Erreur lors de la transformation de la moyenne de classe : " + err.getMessage();
+                    log.error("[Competences@DefaultNoteService::transformMoyenneClasse] " + errorMessage);
                 });
 
         return promise.future();


### PR DESCRIPTION
## Describe your changes

This pull request introduces several enhancements and refactoring to the handling of subject averages and class-level calculations in the competences service. The main changes include the addition of new field constants, improvements to the calculation and transformation logic for subject and class averages, and code cleanup for consistency. These updates aim to provide more accurate and flexible handling of averages, especially for cases involving special statuses (such as "EA" and "NN") and third-class level students.

### Field Constants and Consistency

* Added new constants to `Field.java` for more granular handling of averages and status fields, such as `NULL`, `NULLFINALE`, `MOYENNEFINALE`, `MOYENNESFINALE`, and `MOYENNESCLASSE`. This improves clarity and prevents hardcoded string usage throughout the codebase. [[1]](diffhunk://#diff-c34b809154a211a0a4d96d4fab729cd43c75451b50ebeb04fda2d161ed70914dR166-R167) [[2]](diffhunk://#diff-c34b809154a211a0a4d96d4fab729cd43c75451b50ebeb04fda2d161ed70914dR186-R195)

### Subject and Class Average Calculation Improvements

* Refactored the logic for calculating and storing final averages (`moyenneFinale`) and class averages (`moyennesClasse`) in `DefaultBilanPerioqueService` and `DefaultNoteService`. This includes a new `transformResults` method to enrich results with final averages and ensure proper handling of third-class level students.
* Added a transformation step (`transformMoyenneClasse`) to replace "NN" with "EA" for relevant fields when the user is in the third-class level, ensuring accurate representation of special cases in class averages.

### Codebase Consistency and Cleanup

* Replaced hardcoded string usages for field names with constants from `Field.java` in multiple locations, improving maintainability and reducing errors. [[1]](diffhunk://#diff-7e984dbb62e2b9829d1a5afb916da6b9e824e5fcd238e330b384d1a6c7fd9e7fL373-R378) [[2]](diffhunk://#diff-7e984dbb62e2b9829d1a5afb916da6b9e824e5fcd238e330b384d1a6c7fd9e7fL473-R478) [[3]](diffhunk://#diff-7e984dbb62e2b9829d1a5afb916da6b9e824e5fcd238e330b384d1a6c7fd9e7fR512-R607)
* Renamed occurrences of `_moyenne_classe` to use the new constant `_MOYENNE_CLASSE` throughout `DefaultNoteService`, ensuring consistent naming and easier future updates. [[1]](diffhunk://#diff-731263c5cfc812e20beb1544d9ee368b8ee82443d8f7311fcdf8bf62de9394b4R90) [[2]](diffhunk://#diff-731263c5cfc812e20beb1544d9ee368b8ee82443d8f7311fcdf8bf62de9394b4L3294-R3339) [[3]](diffhunk://#diff-731263c5cfc812e20beb1544d9ee368b8ee82443d8f7311fcdf8bf62de9394b4L3679-R3721) [[4]](diffhunk://#diff-731263c5cfc812e20beb1544d9ee368b8ee82443d8f7311fcdf8bf62de9394b4L3690-R3730) [[5]](diffhunk://#diff-731263c5cfc812e20beb1544d9ee368b8ee82443d8f7311fcdf8bf62de9394b4L4966-R5006)

### Dependency Injection and Service Initialization

* Updated the initialization of `DefaultBilanPerioqueService` to inject a `UserService` instance using a `RepositoryFactory`, supporting new logic for third-class level checks and user-related transformations. [[1]](diffhunk://#diff-7e984dbb62e2b9829d1a5afb916da6b9e824e5fcd238e330b384d1a6c7fd9e7fR47) [[2]](diffhunk://#diff-7e984dbb62e2b9829d1a5afb916da6b9e824e5fcd238e330b384d1a6c7fd9e7fR59-R61)

### Miscellaneous Improvements

* Cleaned up imports and improved the organization of static imports and utility usage for better readability and maintainability. [[1]](diffhunk://#diff-7e984dbb62e2b9829d1a5afb916da6b9e824e5fcd238e330b384d1a6c7fd9e7fL8-R10) [[2]](diffhunk://#diff-7e984dbb62e2b9829d1a5afb916da6b9e824e5fcd238e330b384d1a6c7fd9e7fR19-R30)

These changes collectively improve the flexibility, accuracy, and maintainability of the competences service, especially regarding subject and class average calculations and handling of special cases.

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

